### PR TITLE
EVEREST-277 validate names and namespace

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -60,6 +60,9 @@ func (e *EverestServer) ListDatabaseClusters(ctx echo.Context, kubernetesID stri
 
 // DeleteDatabaseCluster Create a database cluster on the specified kubernetes cluster.
 func (e *EverestServer) DeleteDatabaseCluster(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Cluster name is not RFC 1123 compatible")})
+	}
 	err := e.deleteK8SBackupStorages(ctx.Request().Context(), kubernetesID, name)
 	if err != nil {
 		e.l.Error(err)
@@ -77,6 +80,9 @@ func (e *EverestServer) GetDatabaseCluster(ctx echo.Context, kubernetesID string
 
 // UpdateDatabaseCluster Replace the specified database cluster on the specified kubernetes cluster.
 func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Cluster name is not RFC 1123 compatible")})
+	}
 	dbc, err := getDBCfromContext(ctx)
 	if err != nil {
 		e.l.Error(err)

--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -52,10 +52,16 @@ func (e *EverestServer) CreateDatabaseClusterBackup(ctx echo.Context, kubernetes
 
 // DeleteDatabaseClusterBackup deletes the specified cluster backup on the specified kubernetes cluster.
 func (e *EverestServer) DeleteDatabaseClusterBackup(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Backup name is not RFC 1123 compatible")})
+	}
 	return e.proxyKubernetes(ctx, kubernetesID, name)
 }
 
 // GetDatabaseClusterBackup returns the specified cluster backup on the specified kubernetes cluster.
 func (e *EverestServer) GetDatabaseClusterBackup(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Backup name is not RFC 1123 compatible")})
+	}
 	return e.proxyKubernetes(ctx, kubernetesID, name)
 }

--- a/api/database_cluster_restore.go
+++ b/api/database_cluster_restore.go
@@ -16,7 +16,12 @@
 // Package api ...
 package api
 
-import "github.com/labstack/echo/v4"
+import (
+	"net/http"
+
+	"github.com/AlekSi/pointer"
+	"github.com/labstack/echo/v4"
+)
 
 // ListDatabaseClusterRestores List of the created database cluster restores on the specified kubernetes cluster.
 func (e *EverestServer) ListDatabaseClusterRestores(ctx echo.Context, kubernetesID string) error {
@@ -30,15 +35,24 @@ func (e *EverestServer) CreateDatabaseClusterRestore(ctx echo.Context, kubernete
 
 // DeleteDatabaseClusterRestore Delete the specified cluster restore on the specified kubernetes cluster.
 func (e *EverestServer) DeleteDatabaseClusterRestore(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Restore name is not RFC 1123 compatible")})
+	}
 	return e.proxyKubernetes(ctx, kubernetesID, name)
 }
 
 // GetDatabaseClusterRestore Returns the specified cluster restore on the specified kubernetes cluster.
 func (e *EverestServer) GetDatabaseClusterRestore(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Restore name is not RFC 1123 compatible")})
+	}
 	return e.proxyKubernetes(ctx, kubernetesID, name)
 }
 
 // UpdateDatabaseClusterRestore Replace the specified cluster restore on the specified kubernetes cluster.
 func (e *EverestServer) UpdateDatabaseClusterRestore(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Restore name is not RFC 1123 compatible")})
+	}
 	return e.proxyKubernetes(ctx, kubernetesID, name)
 }

--- a/api/database_engine.go
+++ b/api/database_engine.go
@@ -16,7 +16,12 @@
 // Package api ...
 package api
 
-import "github.com/labstack/echo/v4"
+import (
+	"net/http"
+
+	"github.com/AlekSi/pointer"
+	"github.com/labstack/echo/v4"
+)
 
 // ListDatabaseEngines List of the available database engines on the specified kubernetes cluster.
 func (e *EverestServer) ListDatabaseEngines(ctx echo.Context, kubernetesID string) error {
@@ -25,10 +30,16 @@ func (e *EverestServer) ListDatabaseEngines(ctx echo.Context, kubernetesID strin
 
 // GetDatabaseEngine Get the specified database cluster on the specified kubernetes cluster.
 func (e *EverestServer) GetDatabaseEngine(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Engine name is not RFC 1123 compatible")})
+	}
 	return e.proxyKubernetes(ctx, kubernetesID, name)
 }
 
 // UpdateDatabaseEngine Get the specified database cluster on the specified kubernetes cluster.
 func (e *EverestServer) UpdateDatabaseEngine(ctx echo.Context, kubernetesID string, name string) error {
+	if !validateRFC1123(name) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Engine name is not RFC 1123 compatible")})
+	}
 	return e.proxyKubernetes(ctx, kubernetesID, name)
 }

--- a/api/kubernetes.go
+++ b/api/kubernetes.go
@@ -57,6 +57,9 @@ func (e *EverestServer) RegisterKubernetesCluster(ctx echo.Context) error {
 	if err := ctx.Bind(&params); err != nil {
 		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
 	}
+	if !validateRFC1123(*params.Namespace) {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Namespace name is not RFC 1123 compatible")})
+	}
 	c := ctx.Request().Context()
 
 	_, err := clientcmd.BuildConfigFromKubeconfigGetter("", newConfigGetter(params.Kubeconfig).loadFromString)

--- a/public/dist/index.html
+++ b/public/dist/index.html
@@ -1,1 +1,20 @@
 
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+<title >Percona Everest</title>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      
+      <script>
+      // Allow to use react dev-tools inside the examples
+      try { window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__; } catch {}
+      </script>
+      <!-- minimal css resets -->
+      <style> body { margin: 0; } </style>
+    <link rel="icon" href="/favicon.ico"><script defer src="/static/main.b2c7d428373610dd8875.js"></script></head>
+    <body>
+      <div id="root"></div>
+    </body>
+  </html>
+  


### PR DESCRIPTION
https://jira.percona.com/browse/EVEREST-277

Instead of sanitization, I decided to have validation calls. This one is not generic and before that, I tried to implement either swagger validation or using middleware.
Both other ways require a big effort or API redesign. It turned out that validation middleware or oapi-codegen does not support `pattern` definition in schema.

There are other solutions like this https://github.com/deepmap/oapi-codegen/issues/227#issuecomment-1431333836 or others in the thread but the best thing is to use StrictHandler but it requires a whole API redesign.

I'm open to other options and feel free to reject this PR. However, it solves the problem of security.

proxyKubernetes uses three variables:

1. namespace (added validation before writing the value to the database)
2. name (added validation before proxying request)
3.  resourceName (we have mapping on the be side so they are safe)