### PR TITLE
EVEREST-294 Suggest using docker compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To start using Everest, use the following commands:
 
 ```sh
 wget https://raw.githubusercontent.com/percona/percona-everest-backend/main/quickstart.yml
-docker-compose -f quickstart.yml up -d
+docker compose -f quickstart.yml up -d
 ```
 This will spin up the backend/frontend, accessible at http://127.0.0.1:8080.
 


### PR DESCRIPTION
EVEREST-294
Suggest using docker compose v2 to avoid compatibility issues.