### PR TITLE
EVEREST-321 Disable editing engine version

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -137,6 +137,16 @@ func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID str
 	if err != nil {
 		return errors.Wrap(err, "Could not get old Database Cluster")
 	}
+	if dbc.Spec.Engine.Version != nil {
+		// XXX: Right now we do not support upgrading of versions
+		// because it varies across different engines. Also, we should
+		// prohibit downgrades. Hence, if versions are not equal we just return an error
+		if oldDB.Spec.Engine.Version != *dbc.Spec.Engine.Version {
+			return ctx.JSON(http.StatusBadRequest, Error{
+				Message: pointer.ToString("Changing version is not allowed"),
+			})
+		}
+	}
 
 	newBackupNames := backupStorageNamesFrom(dbc)
 	oldNames := withBackupStorageNamesFromDBCluster(make(map[string]struct{}), *oldDB)

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -119,7 +119,7 @@ func (e *EverestServer) GetDatabaseCluster(ctx echo.Context, kubernetesID string
 }
 
 // UpdateDatabaseCluster replaces the specified database cluster on the specified kubernetes cluster.
-func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID string, name string) error {
+func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID string, name string) error { //nolint:funlen
 	dbc := &DatabaseCluster{}
 	if err := e.getBodyFromContext(ctx, dbc); err != nil {
 		e.l.Error(err)


### PR DESCRIPTION
EVEREST-321

Right now it's the easiest solution to make the version immutable. However, the validation will be improved in EVEREST-256