### PR TITLE
EVEREST-330 Fix backup storage secret format

### DIFF
--- a/model/backup_storage.go
+++ b/model/backup_storage.go
@@ -57,8 +57,8 @@ func (b *BackupStorage) Secrets(ctx context.Context, getSecret func(ctx context.
 		return nil, errors.Wrap(err, "Failed to get accessKey")
 	}
 	return map[string]string{
-		b.SecretKeyID: secretKey,
-		b.AccessKeyID: accessKey,
+		"AWS_SECRET_ACCESS_KEY": secretKey,
+		"AWS_ACCESS_KEY_ID":     accessKey,
 	}, nil
 }
 


### PR DESCRIPTION
EVEREST-330
We were creating the k8s secret with the everest internal secret IDs as the keys while it expects `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.