### PR TITLE
EVEREST-392 accept PMM instance with invalidcert

### DIFF
--- a/pkg/pmm/apikey.go
+++ b/pkg/pmm/apikey.go
@@ -18,6 +18,7 @@ package pmm
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,7 +50,11 @@ func CreatePMMApiKey(ctx context.Context, hostname, apiKeyName, user, password s
 	req.Close = true
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.SetBasicAuth(user, password)
-	resp, err := http.DefaultClient.Do(req)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# !!! Reviewers I'm aware this isn't safe in general, hence the draft PR but I need you to evaluate whether we need to have this right now.
**Accept PMM instance with invalid cert**
---
**Problem:**
EVEREST-392

We can't connect to PMM instances with invalid certs


**Cause:**
go's http module forces TLS cert validation (as it should)

**Solution:**
Don't validate TLS certificate in the initial connection to PMM.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~ No :cry: we don't have the necessary infrastructure in place to do this hours before the release
- ~[ ] Are unit tests added where appropriate?~ Can't unit test this
