### PR TITLE
EVEREST-271 RFC-1035 error messages

### DIFF
--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -118,7 +118,7 @@ test('create backup storage failures', async ({ request }) => {
         accessKey: 'ssdssd',
         secretKey: 'ssdssdssdssd',
       },
-      errorText: '\'name\' is not RFC 1123 compatible',
+      errorText: '\'name\' is not RFC 1035 compatible',
     },
     {
       payload: {

--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -30,8 +30,8 @@ import (
 // ListDatabaseClusterBackups returns list of the created database cluster backups on the specified kubernetes cluster.
 func (e *EverestServer) ListDatabaseClusterBackups(ctx echo.Context, kubernetesID string, name string) error {
 	req := ctx.Request()
-	if err := validateRFC1123(name, "name"); err != nil {
-		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Cluster name is not RFC 1123 compatible")})
+	if err := validateRFC1035(name, "name"); err != nil {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
 	}
 	val := url.Values{}
 	val.Add("labelSelector", fmt.Sprintf("clusterName=%s", name))

--- a/api/database_cluster_restore.go
+++ b/api/database_cluster_restore.go
@@ -30,8 +30,8 @@ import (
 // ListDatabaseClusterRestores List of the created database cluster restores on the specified kubernetes cluster.
 func (e *EverestServer) ListDatabaseClusterRestores(ctx echo.Context, kubernetesID string, name string) error {
 	req := ctx.Request()
-	if err := validateRFC1123(name, "name"); err != nil {
-		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Cluster name is not RFC 1123 compatible")})
+	if err := validateRFC1035(name, "name"); err != nil {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
 	}
 	val := url.Values{}
 	val.Add("labelSelector", fmt.Sprintf("clusterName=%s", name))

--- a/api/validation.go
+++ b/api/validation.go
@@ -42,9 +42,9 @@ var (
 	errDBCNameWrongFormat = errors.New("DatabaseCluster's metadata.name should be a string")
 )
 
-// ErrNameNotRFC1123Compatible when the given fieldName doesn't contain RFC 1123 compatible string.
-func ErrNameNotRFC1123Compatible(fieldName string) error {
-	return errors.Errorf("'%s' is not RFC 1123 compatible. Please use only lowercase alphanumeric characters or '-'", fieldName)
+// ErrNameNotRFC1035Compatible when the given fieldName doesn't contain RFC 1035 compatible string.
+func ErrNameNotRFC1035Compatible(fieldName string) error {
+	return errors.Errorf("'%s' is not RFC 1035 compatible. Please use only lowercase alphanumeric characters or '-'", fieldName)
 }
 
 // ErrNameTooLong when the given fieldName is longer than expected.
@@ -67,18 +67,18 @@ func ErrInvalidURL(fieldName string) error {
 	return errors.Errorf("'%s' is an invalid URL", fieldName)
 }
 
-// validates names to be RFC-1123 compatible  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-func validateRFC1123(s, name string) error {
-	// We are diverging from the RFC1123 spec in regards to the length of the
+// validates names to be RFC-1035 compatible  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
+func validateRFC1035(s, name string) error {
+	// We are diverging from the RFC1035 spec in regards to the length of the
 	// name because the PXC operator limits the name of the cluster to 22.
 	if len(s) > 22 {
 		return ErrNameTooLong(name)
 	}
 
-	rfc1123Regex := "^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$"
-	re := regexp.MustCompile(rfc1123Regex)
+	rfc1035Regex := "^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$"
+	re := regexp.MustCompile(rfc1035Regex)
 	if !re.MatchString(s) {
-		return ErrNameNotRFC1123Compatible(name)
+		return ErrNameNotRFC1035Compatible(name)
 	}
 
 	return nil
@@ -192,7 +192,7 @@ func validateCreateBackupStorageRequest(ctx echo.Context, l *zap.SugaredLogger) 
 		return nil, err
 	}
 
-	if err := validateRFC1123(params.Name, "name"); err != nil {
+	if err := validateRFC1035(params.Name, "name"); err != nil {
 		return nil, err
 	}
 
@@ -218,7 +218,7 @@ func validateCreateMonitoringInstanceRequest(ctx echo.Context) (*CreateMonitorin
 		return nil, err
 	}
 
-	if err := validateRFC1123(params.Name, "name"); err != nil {
+	if err := validateRFC1035(params.Name, "name"); err != nil {
 		return nil, err
 	}
 
@@ -297,7 +297,7 @@ func validateCreateDatabaseClusterRequest(dbc DatabaseCluster) error {
 		return errDBCNameWrongFormat
 	}
 
-	return validateRFC1123(strName, "metadata.name")
+	return validateRFC1035(strName, "metadata.name")
 }
 
 func (e *EverestServer) validateDBClusterAccess(ctx echo.Context, kubernetesID, dbClusterName string) error {

--- a/api/validation.go
+++ b/api/validation.go
@@ -75,7 +75,7 @@ func validateRFC1123(s, name string) error {
 		return ErrNameTooLong(name)
 	}
 
-	rfc1123Regex := "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$"
+	rfc1123Regex := "^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$"
 	re := regexp.MustCompile(rfc1123Regex)
 	if !re.MatchString(s) {
 		return ErrNameNotRFC1123Compatible(name)

--- a/api/validation.go
+++ b/api/validation.go
@@ -44,7 +44,9 @@ var (
 
 // ErrNameNotRFC1035Compatible when the given fieldName doesn't contain RFC 1035 compatible string.
 func ErrNameNotRFC1035Compatible(fieldName string) error {
-	return errors.Errorf("'%s' is not RFC 1035 compatible. Please use only lowercase alphanumeric characters or '-'", fieldName)
+	return errors.Errorf(`'%s' is not RFC 1035 compatible. The name should contain only lowercase alphanumeric characters or '-', start with an alphabetic character, end with an alphanumeric character`,
+		fieldName,
+	)
 }
 
 // ErrNameTooLong when the given fieldName is longer than expected.

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateRFC1123(t *testing.T) {
+func TestValidateRFC1035(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
 		value string
@@ -78,7 +78,7 @@ func TestValidateRFC1123(t *testing.T) {
 		c := tc
 		t.Run(c.value, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, c.valid, validateRFC1123(c.value, "") == nil)
+			require.Equal(t, c.valid, validateRFC1035(c.value, "") == nil)
 		})
 	}
 }
@@ -107,28 +107,28 @@ func TestValidateCreateDatabaseClusterRequest(t *testing.T) {
 			value: DatabaseCluster{Metadata: &map[string]interface{}{
 				"name": "",
 			}},
-			err: ErrNameNotRFC1123Compatible("metadata.name"),
+			err: ErrNameNotRFC1035Compatible("metadata.name"),
 		},
 		{
 			name: "starts with -",
 			value: DatabaseCluster{Metadata: &map[string]interface{}{
 				"name": "-sdfasa",
 			}},
-			err: ErrNameNotRFC1123Compatible("metadata.name"),
+			err: ErrNameNotRFC1035Compatible("metadata.name"),
 		},
 		{
 			name: "ends with -",
 			value: DatabaseCluster{Metadata: &map[string]interface{}{
 				"name": "sdfasa-",
 			}},
-			err: ErrNameNotRFC1123Compatible("metadata.name"),
+			err: ErrNameNotRFC1035Compatible("metadata.name"),
 		},
 		{
 			name: "contains uppercase",
 			value: DatabaseCluster{Metadata: &map[string]interface{}{
 				"name": "AAsdf",
 			}},
-			err: ErrNameNotRFC1123Compatible("metadata.name"),
+			err: ErrNameNotRFC1035Compatible("metadata.name"),
 		},
 		{
 			name: "valid",

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -45,7 +45,11 @@ func TestValidateRFC1123(t *testing.T) {
 			valid: false,
 		},
 		{
-			value: "1abc-sAAf12",
+			value: "abc-sAAf12",
+			valid: false,
+		},
+		{
+			value: "1abc-sf12",
 			valid: false,
 		},
 		{


### PR DESCRIPTION
[![EVEREST-271](https://badgen.net/badge/JIRA/EVEREST-271/green)](https://jira.percona.com/browse/EVEREST-271) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Update error messages**
---
**Problem:**
EVEREST-271

Outdated error message/function names that refers to RFC-1123

**Cause:**
PXC imposes to follow RFC-1035 + the rule of maximum length 22. 

**Solution:**
Update the error message and the naming in the codebase

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?