### PR TITLE
EVEREST-435 Ensure Backend does not run uncontrollable goroutines

### DIFF
--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -62,12 +62,9 @@ test.beforeAll(async ({ request }) => {
 
 test.afterAll(async ({ request }) => {
   let res = await request.delete(`/v1/monitoring-instances/${monitoringConfigName1}`)
-  console.log(await res.text())
-
   expect(res.ok()).toBeTruthy()
 
   res = await request.delete(`/v1/monitoring-instances/${monitoringConfigName2}`)
-  console.log(await res.text())
   expect(res.ok()).toBeTruthy()
 })
 

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -20,8 +20,8 @@ const testPrefix = `${(Math.random() + 1).toString(36).substring(10)}`
 
 let kubernetesId
 let recommendedVersion
-const monitoringConfigName1 = `${testPrefix}-1`
-const monitoringConfigName2 = `${testPrefix}-2`
+const monitoringConfigName1 = `a${testPrefix}-1`
+const monitoringConfigName2 = `b${testPrefix}-2`
 
 test.setTimeout(360 * 1000)
 
@@ -62,10 +62,12 @@ test.beforeAll(async ({ request }) => {
 
 test.afterAll(async ({ request }) => {
   let res = await request.delete(`/v1/monitoring-instances/${monitoringConfigName1}`)
+  console.log(await res.text())
 
   expect(res.ok()).toBeTruthy()
 
   res = await request.delete(`/v1/monitoring-instances/${monitoringConfigName2}`)
+  console.log(await res.text())
   expect(res.ok()).toBeTruthy()
 })
 

--- a/api/backup_storage.go
+++ b/api/backup_storage.go
@@ -137,7 +137,7 @@ func (e *EverestServer) CreateBackupStorage(ctx echo.Context) error { //nolint:f
 }
 
 // DeleteBackupStorage deletes the specified backup storage.
-func (e *EverestServer) DeleteBackupStorage(ctx echo.Context, backupStorageName string) error {
+func (e *EverestServer) DeleteBackupStorage(ctx echo.Context, backupStorageName string) error { //nolint:cyclop
 	c := ctx.Request().Context()
 	bs, err := e.storage.GetBackupStorage(c, nil, backupStorageName)
 	if err != nil {

--- a/api/backup_storage.go
+++ b/api/backup_storage.go
@@ -290,6 +290,7 @@ func (e *EverestServer) performBackupStorageUpdate(
 	if len(ks) == 0 {
 		return ctx.JSON(http.StatusInternalServerError, Error{Message: pointer.ToString("No registered kubernetes clusters available")})
 	}
+	// FIXME: Revisit it once multi k8s support will be enabled
 	_, kubeClient, _, err := e.initKubeClient(ctx.Request().Context(), ks[0].ID)
 	if err != nil {
 		e.l.Error(errors.Wrap(err, "could not init kube client to update config"))

--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -113,6 +113,7 @@ func (e *EverestServer) DeleteDatabaseClusterBackup(ctx echo.Context, kubernetes
 		bsNames := map[string]struct{}{
 			backup.Spec.BackupStorageName: {},
 		}
+		e.waitGroup.Add(1)
 		go e.deleteK8SBackupStorages(context.Background(), kubeClient, bsNames)
 	}
 

--- a/api/database_cluster_restore.go
+++ b/api/database_cluster_restore.go
@@ -114,6 +114,7 @@ func (e *EverestServer) DeleteDatabaseClusterRestore(ctx echo.Context, kubernete
 		bsNames := map[string]struct{}{
 			restore.Spec.DataSource.BackupSource.BackupStorageName: {},
 		}
+		e.waitGroup.Add(1)
 		go e.deleteK8SBackupStorages(context.Background(), kubeClient, bsNames)
 	}
 
@@ -184,7 +185,7 @@ func (e *EverestServer) UpdateDatabaseClusterRestore(ctx echo.Context, kubernete
 	toDeleteNames := map[string]struct{}{
 		oldRestore.Spec.DataSource.BackupSource.BackupStorageName: {},
 	}
-
+	e.waitGroup.Add(1)
 	go e.deleteK8SBackupStorages(context.Background(), kubeClient, toDeleteNames)
 	return nil
 }

--- a/api/kubernetes.go
+++ b/api/kubernetes.go
@@ -71,7 +71,7 @@ func (e *EverestServer) RegisterKubernetesCluster(ctx echo.Context) error {
 	}
 	c := ctx.Request().Context()
 
-	_, err := clientcmd.BuildConfigFromKubeconfigGetter("", newConfigGetter(params.Kubeconfig).loadFromString)
+	_, err = clientcmd.BuildConfigFromKubeconfigGetter("", newConfigGetter(params.Kubeconfig).loadFromString)
 	if err != nil {
 		e.l.Error(err)
 		return ctx.JSON(http.StatusInternalServerError, Error{

--- a/api/kubernetes.go
+++ b/api/kubernetes.go
@@ -63,7 +63,7 @@ func (e *EverestServer) RegisterKubernetesCluster(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Could not list Kubernetes clusters")})
 	}
 	if len(list) != 0 {
-		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Everest does not support multi kubernetes clusters right now. Please delete existing clusters before registering a new one")})
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Everest does not support multiple kubernetes clusters right now. Please delete the existing cluster before registering a new one")})
 	}
 	var params CreateKubernetesClusterParams
 	if err := ctx.Bind(&params); err != nil {

--- a/api/kubernetes.go
+++ b/api/kubernetes.go
@@ -57,6 +57,14 @@ func (e *EverestServer) ListKubernetesClusters(ctx echo.Context) error {
 
 // RegisterKubernetesCluster registers a k8s cluster in Everest server.
 func (e *EverestServer) RegisterKubernetesCluster(ctx echo.Context) error {
+	list, err := e.storage.ListKubernetesClusters(ctx.Request().Context())
+	if err != nil {
+		e.l.Error(err)
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Could not list Kubernetes clusters")})
+	}
+	if len(list) != 0 {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString("Everest does not support multi kubernetes clusters right now. Please delete existing clusters before registering a new one")})
+	}
 	var params CreateKubernetesClusterParams
 	if err := ctx.Bind(&params); err != nil {
 		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})

--- a/api/monitoring_instance.go
+++ b/api/monitoring_instance.go
@@ -270,6 +270,9 @@ func (e *EverestServer) performMonitoringInstanceUpdate(
 			return errors.New("Could not find updated monitoring instance")
 		}
 		// FIXME: Revisit it once multi k8s support will be enabled
+		// FIXME: This is not recommended to do network calls in a database transaction
+		// This will be removed during the implementation of multi k8s support
+		// However, right now it guarantees data consistency
 		_, kubeClient, _, err := e.initKubeClient(ctx.Request().Context(), ks[0].ID)
 		if err != nil {
 			return errors.Wrap(err, "could not init kube client to update config")

--- a/api/monitoring_instance.go
+++ b/api/monitoring_instance.go
@@ -147,7 +147,7 @@ func (e *EverestServer) UpdateMonitoringInstance(ctx echo.Context, name string) 
 }
 
 // DeleteMonitoringInstance deletes a monitoring instance.
-func (e *EverestServer) DeleteMonitoringInstance(ctx echo.Context, name string) error {
+func (e *EverestServer) DeleteMonitoringInstance(ctx echo.Context, name string) error { //nolint:cyclop
 	i, err := e.storage.GetMonitoringInstance(name)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		e.l.Error(err)
@@ -172,7 +172,7 @@ func (e *EverestServer) DeleteMonitoringInstance(ctx echo.Context, name string) 
 	_, kubeClient, _, err := e.initKubeClient(ctx.Request().Context(), ks[0].ID)
 	if err != nil {
 		e.l.Error(errors.Wrap(err, "could not init kube client"))
-		return nil
+		return ctx.JSON(http.StatusInternalServerError, Error{Message: pointer.ToString("Could not make connection to the kubernetes cluster")})
 	}
 
 	err = kubeClient.DeleteConfig(ctx.Request().Context(), i, func(ctx context.Context, name string) (bool, error) {
@@ -180,7 +180,7 @@ func (e *EverestServer) DeleteMonitoringInstance(ctx echo.Context, name string) 
 	})
 	if err != nil && !errors.Is(err, kubernetes.ErrConfigInUse) {
 		e.l.Error(errors.Wrap(err, "could not delete monitoring config from kubernetes cluster"))
-		return nil
+		return ctx.JSON(http.StatusInternalServerError, Error{Message: pointer.ToString("Could not delete monitoring config from the Kubernetes cluster")})
 	}
 
 	err = e.storage.Transaction(func(tx *gorm.DB) error {
@@ -237,7 +237,7 @@ func (e *EverestServer) createAndStorePMMApiKey(ctx context.Context, name, url, 
 	return apiKeyID, nil
 }
 
-func (e *EverestServer) performMonitoringInstanceUpdate(
+func (e *EverestServer) performMonitoringInstanceUpdate( //nolint:cyclop
 	ctx echo.Context, name string, apiKeyID *string, previousAPIKeyID string,
 	params *UpdateMonitoringInstanceJSONRequestBody,
 ) error {
@@ -257,7 +257,7 @@ func (e *EverestServer) performMonitoringInstanceUpdate(
 		})
 		if err != nil {
 			if _, err := e.secretsStorage.DeleteSecret(ctx.Request().Context(), *apiKeyID); err != nil {
-				return errors.Wrapf(err, "Could not delete secret %s from secret storage due to error: %s", apiKeyID)
+				return errors.Wrapf(err, "Could not delete secret %s from secret storage", *apiKeyID)
 			}
 
 			e.l.Error(err)

--- a/api/monitoring_instance.go
+++ b/api/monitoring_instance.go
@@ -176,7 +176,7 @@ func (e *EverestServer) DeleteMonitoringInstance(ctx echo.Context, name string) 
 	}
 
 	err = kubeClient.DeleteConfig(ctx.Request().Context(), i, func(ctx context.Context, name string) (bool, error) {
-		return kubernetes.IsBackupStorageConfigInUse(ctx, name, kubeClient)
+		return kubernetes.IsMonitoringConfigInUse(ctx, name, kubeClient)
 	})
 	if err != nil && !errors.Is(err, kubernetes.ErrConfigInUse) {
 		e.l.Error(errors.Wrap(err, "could not delete monitoring config from kubernetes cluster"))

--- a/pkg/configs/configs.go
+++ b/pkg/configs/configs.go
@@ -43,8 +43,9 @@ func DeleteConfigFromK8sClusters(
 	initKubeClient initKubeClientFn,
 	isInUse isInUseFn,
 	l *zap.SugaredLogger,
+	wg *sync.WaitGroup,
 ) {
-	wg := &sync.WaitGroup{}
+	defer wg.Done()
 
 	// Delete configs in all k8s clusters
 	for _, k := range kubernetesClusters {
@@ -75,10 +76,9 @@ func DeleteConfigFromK8sClusters(
 // UpdateConfigInAllK8sClusters updates config resources in all the provided Kubernetes clusters.
 func UpdateConfigInAllK8sClusters(
 	ctx context.Context, kubernetesClusters []model.KubernetesCluster, cfg kubernetes.ConfigK8sResourcer,
-	getSecret getSecretFn, initKubeClient initKubeClientFn, l *zap.SugaredLogger,
+	getSecret getSecretFn, initKubeClient initKubeClientFn, l *zap.SugaredLogger, wg *sync.WaitGroup,
 ) {
-	wg := &sync.WaitGroup{}
-
+	defer wg.Done()
 	// Update configs in all k8s clusters
 	for _, k := range kubernetesClusters {
 		k := k

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -17,6 +17,8 @@
 package client
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +67,7 @@ func NewFromKubeConfig(kubeconfig []byte, namespace string) (*Client, error) {
 
 	config.QPS = defaultQPSLimit
 	config.Burst = defaultBurstLimit
+	config.Timeout = 10 * time.Second
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
[![EVEREST-435](https://badgen.net/badge/JIRA/EVEREST-435/green)](https://jira.percona.com/browse/EVEREST-435) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-435

*Short explanation of the problem.*
The backend runs a lot of goroutines without cancellation/synchronization and it's unclear when they exit

**Related pull requests**

- [link]

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Since Everest supports only one kubernetes installation it does not make any sense to perform operations against kubernetes clusters asynchronously and it has a lot of side effects such as broken graceful shutdown which may lead to data inconsistency across k8s and storages. 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?