### PR TITLE
EVEREST-107 fix dev-latest: locked bvm version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm i -g @teambit/bvm
 
       - name: Install latest Bit version
-        run: bvm install
+        run: bvm install 0.2.3
 
       - name: Add bvm bin folder to path
         run: echo "$HOME/bin" >> $GITHUB_PATH


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Locked bvm version**
---

To avoid problems with the bit versions, the FE pipeline currently locks the bvm version, let's use the same approach for the dev-latest builds. 
It works, tested it here https://github.com/percona/percona-everest-backend/pull/157