### PR TITLE
EVEREST-428-rc-pipeline

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -14,8 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      VERSION: ${{ github.event.inputs.version }}
-      RC_BRANCH: release-${{ github.event.inputs.version#v }}
+      #VERSION: ${{ github.event.inputs.version }}
+      VERSION: v100.100.100
+      RC_BRANCH: release-$VERSION#v
     steps:
       - name: Validate input
         run: |
@@ -30,22 +31,22 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
-      - name: Check out frontend repo
-        uses: actions/checkout@v4
-        with:
-          repository: percona/percona-everest-frontend
-          ref: 'main'
-          path: percona-everest-frontend
-          token: ${{ secrets.ROBOT_TOKEN }}
-          run: |
-            cd percona-everest-frontend
-          
-            # Check if the branch already exists
-            if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-              git checkout -b $RC_BRANCH origin/main
-            else
-              git checkout $RC_BRANCH
-            fi
+#      - name: Check out frontend repo
+#        uses: actions/checkout@v4
+#        with:
+#          repository: percona/percona-everest-frontend
+#          ref: 'main'
+#          path: percona-everest-frontend
+#          token: ${{ secrets.ROBOT_TOKEN }}
+#          run: |
+#            cd percona-everest-frontend
+#
+#            # Check if the branch already exists
+#            if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+#              git checkout -b $RC_BRANCH origin/main
+#            else
+#              git checkout $RC_BRANCH
+#            fi
 
 #      - name: Run with Node 16
 #        uses: actions/setup-node@v3
@@ -76,13 +77,11 @@ jobs:
 #          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 #
       - name: Check out Everest Backend
-        uses: actions/checkout@v4
-        with:
-          path: ./backend
         run: |
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH origin/main
+            git push origin $RC_BRANCH
           else
             git checkout $RC_BRANCH
           fi

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -155,7 +155,7 @@ jobs:
           git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
           EXIT_CODE=$?
           
-          if [[ $EXIT_CODE != '0' ]]; then
+          if [[ $EXIT_CODE == '2' ]]; then
             git checkout -b $RC_BRANCH
             # update tag refs in scripts
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
       - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
-      - rc-test                     # <-- DELETE ME before merge
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,79 +35,79 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
-#      - name: Check out Everest CLI
-#        uses: actions/checkout@v4
-#        with:
-#          repository: percona/percona-everest-cli
-#          ref: 'main'
-#          path: percona-everest-cli
-#          token: ${{ secrets.ROBOT_TOKEN }}
-#
-#      - name: Check out Everest CLI RC-branch
-#        run: |
-#          cd percona-everest-cli
-#          # Check if the branch already exists
-#          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-#          EXIT_CODE=$?
-#
-#          if [[ $EXIT_CODE != '0' ]]; then
-#            git checkout -b $RC_BRANCH
-#            git push origin $RC_BRANCH
-#          else
-#            git checkout $RC_BRANCH
-#          fi
-#
-#
-#      - name: Check out Everest frontend
-#        uses: actions/checkout@v4
-#        with:
-#          repository: percona/percona-everest-frontend
-#          ref: 'main'
-#          path: percona-everest-frontend
-#          token: ${{ secrets.ROBOT_TOKEN }}
-#
-#      - name: Check out Everest Frontend RC-branch
-#        run: |
-#          cd percona-everest-frontend
-#
-#          # Check if the branch already exists
-#          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-#          EXIT_CODE=$?
-#
-#          if [[ $EXIT_CODE != '0' ]]; then
-#            git checkout -b $RC_BRANCH
-#            git push origin $RC_BRANCH
-#          else
-#            git checkout $RC_BRANCH
-#          fi
-#
-#      - name: Run with Node 16
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: ${{ matrix.node-version }}
-#
-#      - name: Install Bit Version Manager
-#        run: npm i -g @teambit/bvm
-#
-#      - name: Install latest Bit version
-#        run: bvm install 0.2.3
-#
-#      - name: Add bvm bin folder to path
-#        run: echo "$HOME/bin" >> $GITHUB_PATH
-#
-#      - name: Set up bit config
-#        env:
-#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-#        run: bit config set user.token $BIT_TOKEN
-#
-#      - name: Build Everest Frontend app
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-#          bit install --recurring-install
-#          bit snap
-#          bit artifacts percona.apps/everest --out-dir build
-#          mkdir ${GITHUB_WORKSPACE}/front
-#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+      - name: Check out Everest CLI
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-cli
+          ref: 'main'
+          path: percona-everest-cli
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Check out Everest CLI RC-branch
+        run: |
+          cd percona-everest-cli
+          # Check if the branch already exists
+          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+
+          if [[ $EXIT_CODE != '0' ]]; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH
+          else
+            git checkout $RC_BRANCH
+          fi
+
+
+      - name: Check out Everest frontend
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-frontend
+          ref: 'main'
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Check out Everest Frontend RC-branch
+        run: |
+          cd percona-everest-frontend
+
+          # Check if the branch already exists
+          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+
+          if [[ $EXIT_CODE != '0' ]]; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH
+          else
+            git checkout $RC_BRANCH
+          fi
+
+      - name: Run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Build Everest Frontend app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -136,28 +136,28 @@ jobs:
             git checkout $RC_BRANCH
           fi
 
-#      - name: Embed Everest Frontend app into backend
-#        run: |
-#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-#          cd ${GITHUB_WORKSPACE}/backend
+      - name: Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
 
-#      - name: Setup docker build metadata
-#        uses: docker/metadata-action@v4
-#        id: meta
-#        with:
-#          images: perconalab/everest
-#          tags: ${{ env.VERSION }}
-#
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v2
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build and Push everest RC-image
-#        uses: docker/build-push-action@v4
-#        with:
-#          context: backend
-#          push: true
-#          tags: ${{ steps.meta.outputs.tags }}
+      - name: Setup docker build metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: perconalab/everest
+          tags: ${{ env.VERSION }}
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push everest RC-image
+        uses: docker/build-push-action@v4
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -92,7 +92,7 @@ jobs:
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH
-            sed -i "s/dev-latest/$BRANCH_NAME/g" deploy/quickstart-compose.yml
+            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml
             git diff deploy/quickstart-compose.yml
             #git commit -a -m "update version tag"
             #git push origin $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -116,7 +116,7 @@ jobs:
           git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
           EXIT_CODE=$?
           
-          if [[ $EXIT_CODE == '0' ]]; then
+          if [[ $EXIT_CODE != '0' ]]; then
           
           #if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -35,13 +35,6 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
-      - name: Configure git user for commits
-        env:
-          ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
-        run: |
-          git config --global user.email "oksana.grishchenko@percona.com"
-          git config --global user.name "Everest RC CI"
-
       - name: Check out Everest CLI
         uses: actions/checkout@v4
         with:
@@ -150,10 +143,15 @@ jobs:
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH
+            
             # update tag refs in scripts
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
-            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+            
             # configure userdata for commits
+            git config --global user.email "oksana.grishchenko@percona.com"
+            git config --global user.name "Everest RC CI"
+            
+            # commit and push the updated files
             git commit -a -m "update version tag"
             git push origin $RC_BRANCH  
           else

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -152,10 +152,9 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          EXIT_CODE=$?
+          git fetch && $check=(git ls-remote --heads origin $RC_BRANCH) 
           
-          if [[ $EXIT_CODE == '2' ]]; then
+          if [[ -z ${check} ]]; then
             git checkout -b $RC_BRANCH
             # update tag refs in scripts
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       #VERSION: ${{ github.event.inputs.version }}
       VERSION: v100.100.100
-      RC_BRANCH: release-${VERSION#v}
+      RC_BRANCH: ''
     steps:
       - name: Validate input
         run: |
@@ -25,9 +25,9 @@ jobs:
             echo "Wrong version format provided, please use v*.*.* format" 
             exit 1
           fi
-#      - name: Define release branch
-#        run: |
-#          echo "release-${VERSION#v}" >> $GITHUB_ENV
+      - name: Define release branch
+        run: |
+          echo "RC_BRANCH=release-${VERSION#v}" >> $GITHUB_ENV
 
       - name: Print RC_BRANCH
         run: echo $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -34,80 +34,79 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
-      - name: Check out Everest CLI
-        uses: actions/checkout@v4
-        with:
-          repository: percona/percona-everest-cli
-          ref: 'main'
-          path: percona-everest-cli
-          token: ${{ secrets.ROBOT_TOKEN }}
-
-
-      - name: Check out Everest CLI RC-branch
-        run: |
-          cd percona-everest-cli
-          # Check if the branch already exists
-          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          EXIT_CODE=$?
-          
-          if [[ $EXIT_CODE != '0' ]]; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH
-          else
-            git checkout $RC_BRANCH
-          fi
-
-
-      - name: Check out Everest frontend
-        uses: actions/checkout@v4
-        with:
-          repository: percona/percona-everest-frontend
-          ref: 'main'
-          path: percona-everest-frontend
-          token: ${{ secrets.ROBOT_TOKEN }}
-
-      - name: Check out Everest Frontend RC-branch
-        run: |
-          cd percona-everest-frontend
-
-          # Check if the branch already exists
-          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          EXIT_CODE=$?
-          
-          if [[ $EXIT_CODE != '0' ]]; then
-            git checkout -b $RC_BRANCH 
-            git push origin $RC_BRANCH
-          else
-            git checkout $RC_BRANCH
-          fi
-
-      - name: Run with Node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install Bit Version Manager
-        run: npm i -g @teambit/bvm
-
-      - name: Install latest Bit version
-        run: bvm install 0.2.3
-
-      - name: Add bvm bin folder to path
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Set up bit config
-        env:
-          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-        run: bit config set user.token $BIT_TOKEN
-
-      - name: Build Everest Frontend app
-        run: |
-          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-          bit install --recurring-install
-          bit snap
-          bit artifacts percona.apps/everest --out-dir build
-          mkdir ${GITHUB_WORKSPACE}/front
-          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+#      - name: Check out Everest CLI
+#        uses: actions/checkout@v4
+#        with:
+#          repository: percona/percona-everest-cli
+#          ref: 'main'
+#          path: percona-everest-cli
+#          token: ${{ secrets.ROBOT_TOKEN }}
+#
+#      - name: Check out Everest CLI RC-branch
+#        run: |
+#          cd percona-everest-cli
+#          # Check if the branch already exists
+#          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+#          EXIT_CODE=$?
+#
+#          if [[ $EXIT_CODE != '0' ]]; then
+#            git checkout -b $RC_BRANCH
+#            git push origin $RC_BRANCH
+#          else
+#            git checkout $RC_BRANCH
+#          fi
+#
+#
+#      - name: Check out Everest frontend
+#        uses: actions/checkout@v4
+#        with:
+#          repository: percona/percona-everest-frontend
+#          ref: 'main'
+#          path: percona-everest-frontend
+#          token: ${{ secrets.ROBOT_TOKEN }}
+#
+#      - name: Check out Everest Frontend RC-branch
+#        run: |
+#          cd percona-everest-frontend
+#
+#          # Check if the branch already exists
+#          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+#          EXIT_CODE=$?
+#
+#          if [[ $EXIT_CODE != '0' ]]; then
+#            git checkout -b $RC_BRANCH
+#            git push origin $RC_BRANCH
+#          else
+#            git checkout $RC_BRANCH
+#          fi
+#
+#      - name: Run with Node 16
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#
+#      - name: Install Bit Version Manager
+#        run: npm i -g @teambit/bvm
+#
+#      - name: Install latest Bit version
+#        run: bvm install 0.2.3
+#
+#      - name: Add bvm bin folder to path
+#        run: echo "$HOME/bin" >> $GITHUB_PATH
+#
+#      - name: Set up bit config
+#        env:
+#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+#        run: bit config set user.token $BIT_TOKEN
+#
+#      - name: Build Everest Frontend app
+#        run: |
+#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+#          bit install --recurring-install
+#          bit snap
+#          bit artifacts percona.apps/everest --out-dir build
+#          mkdir ${GITHUB_WORKSPACE}/front
+#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -136,28 +135,28 @@ jobs:
             git checkout $RC_BRANCH
           fi
 
-      - name: Embed Everest Frontend app into backend
-        run: |
-          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-          cd ${GITHUB_WORKSPACE}/backend
+#      - name: Embed Everest Frontend app into backend
+#        run: |
+#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+#          cd ${GITHUB_WORKSPACE}/backend
 
-      - name: Setup docker build metadata
-        uses: docker/metadata-action@v4
-        id: meta
-        with:
-          images: perconalab/everest
-          tags: ${{ env.VERSION }}
-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and Push everest RC-image
-        uses: docker/build-push-action@v4
-        with:
-          context: backend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+#      - name: Setup docker build metadata
+#        uses: docker/metadata-action@v4
+#        id: meta
+#        with:
+#          images: perconalab/everest
+#          tags: ${{ env.VERSION }}
+#
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and Push everest RC-image
+#        uses: docker/build-push-action@v4
+#        with:
+#          context: backend
+#          push: true
+#          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -85,7 +85,8 @@ jobs:
         with:
           path: ./backend
           ref: 'main'
-      - name: Check out Everest Backend
+
+      - name: Check out rc-branch
         run: |
           cd backend
           # Check if the branch already exists
@@ -129,3 +130,24 @@ jobs:
 #          context: backend
 #          push: true
 #          tags: ${{ steps.meta.outputs.tags }}
+
+
+      - name: Check out EVEREST CLI
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-cli
+          ref: 'main'
+          path: percona-everest-cli
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+
+      - name: Check out rc-branch
+        run: |
+          cd percona-everest-cli
+          # Check if the branch already exists
+          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH
+          else
+            git checkout $RC_BRANCH
+          fi

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -3,13 +3,12 @@ name: Build and push RC image
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: An image tag
-        required: false
+      version:
+        description: A release version in vX.Y.Z format
+        required: true
   push:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -43,16 +43,16 @@ jobs:
           token: ${{ secrets.ROBOT_TOKEN }}
 
 
-      - name: Check out Everest CLI RC-branch
-        run: |
-          cd percona-everest-cli
-          # Check if the branch already exists
-          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH
-          else
-            git checkout $RC_BRANCH
-          fi
+#      - name: Check out Everest CLI RC-branch
+#        run: |
+#          cd percona-everest-cli
+#          # Check if the branch already exists
+#          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+#            git checkout -b $RC_BRANCH
+#            git push origin $RC_BRANCH
+#          else
+#            git checkout $RC_BRANCH
+#          fi
 
 
       - name: Check out Everest frontend
@@ -108,23 +108,23 @@ jobs:
           path: ./backend
           ref: 'main'
 
-#      - name: Check out rc-branch
-#        run: |
-#          cd backend
-#          # Check if the branch already exists
-#          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-#            git checkout -b $RC_BRANCH
-#            # update tag refs in scripts
-#            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
-#            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
-#            # configure userdata for commits
-#            git config --global user.email "oksana.grishchenko@percona.com"
-#            git config --global user.name "Everest RC CI"
-#            git commit -a -m "update version tag"
-#            git push origin $RC_BRANCH
-#          else
-#            git checkout $RC_BRANCH
-#          fi
+      - name: Check out Everest Backend rc-branch
+        run: |
+          cd backend
+          # Check if the branch already exists
+          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+            git checkout -b $RC_BRANCH
+            # update tag refs in scripts
+            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+            # configure userdata for commits
+            git config --global user.email "oksana.grishchenko@percona.com"
+            git config --global user.name "Everest RC CI"
+            git commit -a -m "update version tag"
+            git push origin $RC_BRANCH
+          else
+            git checkout $RC_BRANCH
+          fi
 
       - name: Embed Everest Frontend app into backend
         run: |

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -94,6 +94,8 @@ jobs:
             git checkout -b $RC_BRANCH
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+            git config --global user.email "oksana.grishchenko@percona.com"
+            git config --global user.name "Percona Robot"
             git commit -a -m "update version tag"
             git push origin $RC_BRANCH
           else

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -92,8 +92,8 @@ jobs:
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH
-            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yml
-            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yml
+            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             git commit -a -m "update version tag"
             git push origin $RC_BRANCH
           else

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -25,12 +25,9 @@ jobs:
             echo "Wrong version format provided, please use v*.*.* format" 
             exit 1
           fi
-      - name: Define release branch
+      - name: Define release branch name in the format "release-*.*.*"
         run: |
           echo "RC_BRANCH=release-${VERSION#v}" >> $GITHUB_ENV
-
-      - name: Print RC_BRANCH
-        run: echo $RC_BRANCH
 
       - name: Configure git for private modules
         env:
@@ -90,6 +87,9 @@ jobs:
       - name: Check out Everest Backend
         run: |
           cd backend
+          echo "-----"
+          git status
+          echo "-----"
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH origin/main

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -154,6 +154,7 @@ jobs:
           # Check if the branch already exists
           git fetch
           check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          echo "---"
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -6,6 +6,9 @@ on:
       tag:
         description: An image tag
         required: false
+  push:
+    branches:
+      - release-[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
   build:
@@ -15,4 +18,3 @@ jobs:
         env:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
-

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -27,7 +27,7 @@ jobs:
           fi
       - name: Define release branch
         run: |
-          echo "RC_BRANCH=release-$VERSION#v" >> $GITHUB_ENV
+          echo $VERSION#v >> $GITHUB_ENV
 
       - name: Print RC_BRANCH
         run: echo $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -27,7 +27,7 @@ jobs:
           fi
       - name: Define release branch
         run: |
-          echo "RC_BRANCH=release-${{ github.event.inputs.version#v }}" >> $GITHUB_ENV
+          echo "RC_BRANCH=release-$VERSION#v" >> $GITHUB_ENV
           echo $RC_BRANCH
 
       - name: Configure git for private modules

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -152,9 +152,7 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          git fetch
           check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
-          echo "---"
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -156,7 +156,7 @@ jobs:
             git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             # configure userdata for commits
             git commit -a -m "update version tag"
-            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+            git push origin $RC_BRANCH  
           else
             git checkout $RC_BRANCH
           fi

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -162,7 +162,7 @@ jobs:
             git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             # configure userdata for commits
             git commit -a -m "update version tag"
-            git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+            git push origin $RC_BRANCH   
           else
             git checkout $RC_BRANCH
           fi

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -126,10 +126,10 @@ jobs:
             git checkout $RC_BRANCH
           fi
 
-      - name: Embed Everest Frontend app into backend
-        run: |
-          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-          cd ${GITHUB_WORKSPACE}/backend
+#      - name: Embed Everest Frontend app into backend
+#        run: |
+#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+#          cd ${GITHUB_WORKSPACE}/backend
 
       - name: Setup docker build metadata
         uses: docker/metadata-action@v4

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -76,9 +76,13 @@ jobs:
 #          mkdir ${GITHUB_WORKSPACE}/front
 #          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 #
+
+      - name: Check out Everest Backend
+        uses: actions/checkout@v4
+        with:
+          path: ./backend
       - name: Check out Everest Backend
         run: |
-          cd ..
           ls -a
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -83,7 +83,7 @@ jobs:
           path: ./backend
       - name: Check out Everest Backend
         run: |
-          ls -a
+          cd backend
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH origin/main

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -152,8 +152,8 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
+          git fetch
           check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
-          echo "jhj"
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
           EXIT_CODE=$?
           
           if [[ $EXIT_CODE == '0' ]]; then

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -35,6 +35,13 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
+      - name: Configure git user for commits
+        env:
+          ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
+        run: |
+          git config --global user.email "oksana.grishchenko@percona.com"
+          git config --global user.name "Everest RC CI"
+
       - name: Check out Everest CLI
         uses: actions/checkout@v4
         with:
@@ -43,71 +50,88 @@ jobs:
           path: percona-everest-cli
           token: ${{ secrets.ROBOT_TOKEN }}
 
-#      - name: Check out Everest CLI RC-branch
-#        run: |
-#          cd percona-everest-cli
-#          # Check if the branch already exists
-#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-#          EXIT_CODE=$?
-#
-#          if [[ $EXIT_CODE != '0' ]]; then
-#            git checkout -b $RC_BRANCH
-#            git push origin $RC_BRANCH
-#          else
-#            git checkout $RC_BRANCH
-#          fi
+      - name: Check out Everest CLI RC-branch
+        run: |
+          cd percona-everest-cli
+          # Check if the branch already exists
+          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+
+          if [[ $EXIT_CODE != '0' ]]; then
+            git checkout -b $RC_BRANCH
+            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+          
+
+      - name: Check out Everest catalog
+        uses: actions/checkout@v4
+        with:
+          repository: percona/everest-catalog
+          ref: 'main'
+          path: everest-catalog
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Check out Everest catalog RC-branch
+        run: |
+          cd everest-catalog
+          # Check if the branch already exists
+          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+
+          if [[ $EXIT_CODE != '0' ]]; then
+            git checkout -b $RC_BRANCH
+            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
 
 
-#      - name: Check out Everest frontend
-#        uses: actions/checkout@v4
-#        with:
-#          repository: percona/percona-everest-frontend
-#          ref: 'main'
-#          path: percona-everest-frontend
-#          token: ${{ secrets.ROBOT_TOKEN }}
-#
-#      - name: Check out Everest Frontend RC-branch
-#        run: |
-#          cd percona-everest-frontend
-#
-#          # Check if the branch already exists
-#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-#          EXIT_CODE=$?
-#
-#          if [[ $EXIT_CODE != '0' ]]; then
-#            git checkout -b $RC_BRANCH
-#            git push origin $RC_BRANCH
-#          else
-#            git checkout $RC_BRANCH
-#          fi
-#
-#      - name: Run with Node 16
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: ${{ matrix.node-version }}
-#
-#      - name: Install Bit Version Manager
-#        run: npm i -g @teambit/bvm
-#
-#      - name: Install latest Bit version
-#        run: bvm install 0.2.3
-#
-#      - name: Add bvm bin folder to path
-#        run: echo "$HOME/bin" >> $GITHUB_PATH
-#
-#      - name: Set up bit config
-#        env:
-#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-#        run: bit config set user.token $BIT_TOKEN
-#
-#      - name: Build Everest Frontend app
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-#          bit install --recurring-install
-#          bit snap
-#          bit artifacts percona.apps/everest --out-dir build
-#          mkdir ${GITHUB_WORKSPACE}/front
-#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+      - name: Check out Everest frontend
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-frontend
+          ref: 'main'
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Check out Everest Frontend RC-branch
+        run: |
+          cd percona-everest-frontend
+
+          # Check if the branch already exists
+          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+
+          if [[ $EXIT_CODE != '0' ]]; then
+            git checkout -b $RC_BRANCH
+            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+          else
+            git checkout $RC_BRANCH
+          fi
+
+      - name: Run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Build Everest Frontend app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -128,36 +152,34 @@ jobs:
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             # configure userdata for commits
-            git config --global user.email "oksana.grishchenko@percona.com"
-            git config --global user.name "Everest RC CI"
             git commit -a -m "update version tag"
-            git push origin $RC_BRANCH
+            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
           else
             git checkout $RC_BRANCH
           fi
 
-#      - name: Embed Everest Frontend app into backend
-#        run: |
-#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-#          cd ${GITHUB_WORKSPACE}/backend
+      - name: Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
 
-#      - name: Setup docker build metadata
-#        uses: docker/metadata-action@v4
-#        id: meta
-#        with:
-#          images: perconalab/everest
-#          tags: ${{ env.VERSION }}
-#
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v2
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build and Push everest RC-image
-#        uses: docker/build-push-action@v4
-#        with:
-#          context: backend
-#          push: true
-#          tags: ${{ steps.meta.outputs.tags }}
+      - name: Setup docker build metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: perconalab/everest
+          tags: ${{ env.VERSION }}
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push everest RC-image
+        uses: docker/build-push-action@v4
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -153,6 +153,7 @@ jobs:
           cd backend
           # Check if the branch already exists
           check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          echo "jhj"
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -84,15 +84,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./backend
+          ref: 'main'
       - name: Check out Everest Backend
         run: |
           cd backend
-          echo "-----"
-          git status
-          echo "-----"
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-            git checkout -b $RC_BRANCH origin/main
+            git checkout -b $RC_BRANCH
             git push origin $RC_BRANCH
           else
             git checkout $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -55,13 +55,13 @@ jobs:
 #          fi
 
 
-      - name: Check out Everest frontend
-        uses: actions/checkout@v4
-        with:
-          repository: percona/percona-everest-frontend
-          ref: 'main'
-          path: percona-everest-frontend
-          token: ${{ secrets.ROBOT_TOKEN }}
+#      - name: Check out Everest frontend
+#        uses: actions/checkout@v4
+#        with:
+#          repository: percona/percona-everest-frontend
+#          ref: 'main'
+#          path: percona-everest-frontend
+#          token: ${{ secrets.ROBOT_TOKEN }}
 
 #      - name: Check out Everest Frontend RC-branch
 #        run: |
@@ -74,33 +74,33 @@ jobs:
 #            git checkout $RC_BRANCH
 #          fi
 
-      - name: Run with Node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install Bit Version Manager
-        run: npm i -g @teambit/bvm
-
-      - name: Install latest Bit version
-        run: bvm install 0.2.3
-
-      - name: Add bvm bin folder to path
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Set up bit config
-        env:
-          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-        run: bit config set user.token $BIT_TOKEN
-
-      - name: Build Everest Frontend app
-        run: |
-          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-          bit install --recurring-install
-          bit snap
-          bit artifacts percona.apps/everest --out-dir build
-          mkdir ${GITHUB_WORKSPACE}/front
-          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+#      - name: Run with Node 16
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#
+#      - name: Install Bit Version Manager
+#        run: npm i -g @teambit/bvm
+#
+#      - name: Install latest Bit version
+#        run: bvm install 0.2.3
+#
+#      - name: Add bvm bin folder to path
+#        run: echo "$HOME/bin" >> $GITHUB_PATH
+#
+#      - name: Set up bit config
+#        env:
+#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+#        run: bit config set user.token $BIT_TOKEN
+#
+#      - name: Build Everest Frontend app
+#        run: |
+#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+#          bit install --recurring-install
+#          bit snap
+#          bit artifacts percona.apps/everest --out-dir build
+#          mkdir ${GITHUB_WORKSPACE}/front
+#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
             git commit -a -m "update version tag"
             git push origin $RC_BRANCH
           else
-            git checkout $RC_BRANCH
+            git fetch && git checkout $RC_BRANCH
           fi
 
       - name: Embed Everest Frontend app into backend

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -141,23 +141,23 @@ jobs:
 #          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
 #          cd ${GITHUB_WORKSPACE}/backend
 
-      - name: Setup docker build metadata
-        uses: docker/metadata-action@v4
-        id: meta
-        with:
-          images: perconalab/everest
-          tags: ${{ env.VERSION }}
-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and Push everest RC-image
-        uses: docker/build-push-action@v4
-        with:
-          context: backend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+#      - name: Setup docker build metadata
+#        uses: docker/metadata-action@v4
+#        id: meta
+#        with:
+#          images: perconalab/everest
+#          tags: ${{ env.VERSION }}
+#
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and Push everest RC-image
+#        uses: docker/build-push-action@v4
+#        with:
+#          context: backend
+#          push: true
+#          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
           EXIT_CODE=$?
           
           if [[ $EXIT_CODE != '0' ]]; then

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -95,7 +95,7 @@ jobs:
           else
             git checkout $RC_BRANCH
           fi
-#
+
 #      - name: Embed Everest Frontend app into backend
 #        run: |
 #          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -152,9 +152,10 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          git fetch && $check=(git ls-remote --heads origin $RC_BRANCH) 
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
           
-          if [[ -z ${check} ]]; then
+          if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH
             # update tag refs in scripts
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       #VERSION: ${{ github.event.inputs.version }}
       VERSION: v100.100.100
-      RC_BRANCH: release-$VERSION#v
+      RC_BRANCH: ''
     steps:
       - name: Validate input
         run: |
@@ -25,6 +25,10 @@ jobs:
             echo "Wrong version format provided, please use v*.*.* format" 
             exit 1
           fi
+      - name: Define release branch
+        run: |
+          echo "RC_BRANCH=release-${{ github.event.inputs.version#v }}" >> $GITHUB_ENV
+          echo $RC_BRANCH
 
       - name: Configure git for private modules
         env:

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -92,10 +92,10 @@ jobs:
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH
-            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml
-            git diff deploy/quickstart-compose.yml
-            #git commit -a -m "update version tag"
-            #git push origin $RC_BRANCH
+            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yml
+            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yml
+            git commit -a -m "update version tag"
+            git push origin $RC_BRANCH
           else
             git checkout $RC_BRANCH
           fi

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -43,71 +43,71 @@ jobs:
           path: percona-everest-cli
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Check out Everest CLI RC-branch
-        run: |
-          cd percona-everest-cli
-          # Check if the branch already exists
-          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          EXIT_CODE=$?
+#      - name: Check out Everest CLI RC-branch
+#        run: |
+#          cd percona-everest-cli
+#          # Check if the branch already exists
+#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+#          EXIT_CODE=$?
+#
+#          if [[ $EXIT_CODE != '0' ]]; then
+#            git checkout -b $RC_BRANCH
+#            git push origin $RC_BRANCH
+#          else
+#            git checkout $RC_BRANCH
+#          fi
 
-          if [[ $EXIT_CODE != '0' ]]; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH
-          else
-            git checkout $RC_BRANCH
-          fi
 
-
-      - name: Check out Everest frontend
-        uses: actions/checkout@v4
-        with:
-          repository: percona/percona-everest-frontend
-          ref: 'main'
-          path: percona-everest-frontend
-          token: ${{ secrets.ROBOT_TOKEN }}
-
-      - name: Check out Everest Frontend RC-branch
-        run: |
-          cd percona-everest-frontend
-
-          # Check if the branch already exists
-          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          EXIT_CODE=$?
-
-          if [[ $EXIT_CODE != '0' ]]; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH
-          else
-            git checkout $RC_BRANCH
-          fi
-
-      - name: Run with Node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install Bit Version Manager
-        run: npm i -g @teambit/bvm
-
-      - name: Install latest Bit version
-        run: bvm install 0.2.3
-
-      - name: Add bvm bin folder to path
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Set up bit config
-        env:
-          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-        run: bit config set user.token $BIT_TOKEN
-
-      - name: Build Everest Frontend app
-        run: |
-          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-          bit install --recurring-install
-          bit snap
-          bit artifacts percona.apps/everest --out-dir build
-          mkdir ${GITHUB_WORKSPACE}/front
-          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+#      - name: Check out Everest frontend
+#        uses: actions/checkout@v4
+#        with:
+#          repository: percona/percona-everest-frontend
+#          ref: 'main'
+#          path: percona-everest-frontend
+#          token: ${{ secrets.ROBOT_TOKEN }}
+#
+#      - name: Check out Everest Frontend RC-branch
+#        run: |
+#          cd percona-everest-frontend
+#
+#          # Check if the branch already exists
+#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+#          EXIT_CODE=$?
+#
+#          if [[ $EXIT_CODE != '0' ]]; then
+#            git checkout -b $RC_BRANCH
+#            git push origin $RC_BRANCH
+#          else
+#            git checkout $RC_BRANCH
+#          fi
+#
+#      - name: Run with Node 16
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#
+#      - name: Install Bit Version Manager
+#        run: npm i -g @teambit/bvm
+#
+#      - name: Install latest Bit version
+#        run: bvm install 0.2.3
+#
+#      - name: Add bvm bin folder to path
+#        run: echo "$HOME/bin" >> $GITHUB_PATH
+#
+#      - name: Set up bit config
+#        env:
+#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+#        run: bit config set user.token $BIT_TOKEN
+#
+#      - name: Build Everest Frontend app
+#        run: |
+#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+#          bit install --recurring-install
+#          bit snap
+#          bit artifacts percona.apps/everest --out-dir build
+#          mkdir ${GITHUB_WORKSPACE}/front
+#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -136,10 +136,10 @@ jobs:
             git checkout $RC_BRANCH
           fi
 
-      - name: Embed Everest Frontend app into backend
-        run: |
-          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-          cd ${GITHUB_WORKSPACE}/backend
+#      - name: Embed Everest Frontend app into backend
+#        run: |
+#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+#          cd ${GITHUB_WORKSPACE}/backend
 
       - name: Setup docker build metadata
         uses: docker/metadata-action@v4

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
       - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
+      - rc-test                      # <-- DELETE ME before merge
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -92,7 +92,10 @@ jobs:
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH
+            sed -i "s/dev-latest/$BRANCH_NAME/g" deploy/quickstart-compose.yml
+            git diff deploy/quickstart-compose.yml
+            #git commit -a -m "update version tag"
+            #git push origin $RC_BRANCH
           else
             git checkout $RC_BRANCH
           fi

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Define release branch
         run: |
           echo "RC_BRANCH=release-$VERSION#v" >> $GITHUB_ENV
-          echo $RC_BRANCH
+
+      - name: Print RC_BRANCH
+        run: echo $RC_BRANCH
 
       - name: Configure git for private modules
         env:

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -27,7 +27,7 @@ jobs:
           fi
       - name: Define release branch
         run: |
-          echo $VERSION#v >> $GITHUB_ENV
+          echo ${VERSION#v} >> $GITHUB_ENV
 
       - name: Print RC_BRANCH
         run: echo $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -154,7 +154,6 @@ jobs:
           # Check if the branch already exists
           git fetch
           check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
-          echo $check_branch
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH
@@ -163,7 +162,7 @@ jobs:
             git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             # configure userdata for commits
             git commit -a -m "update version tag"
-            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+            git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
           else
             git checkout $RC_BRANCH
           fi

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -51,96 +51,96 @@ jobs:
           path: percona-everest-cli
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Check out Everest CLI RC-branch
-        run: |
-          cd percona-everest-cli
-          # Check if the branch already exists
-          echo "!fetch"
-          git fetch 
-           echo "!ls-remote"
-          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          echo "!exit code"
-          EXIT_CODE=$?
-          echo "!before if"
-          if [[ $EXIT_CODE == '2' ]]; then
-            echo "!in if"
-            git checkout -b $RC_BRANCH
-            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
-             echo "!after if"
-          fi
+#      - name: Check out Everest CLI RC-branch
+#        run: |
+#          cd percona-everest-cli
+#          # Check if the branch already exists
+#          echo "!fetch"
+#          git fetch
+#           echo "!ls-remote"
+#          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+#          echo "!exit code"
+#          EXIT_CODE=$?
+#          echo "!before if"
+#          if [[ $EXIT_CODE == '2' ]]; then
+#            echo "!in if"
+#            git checkout -b $RC_BRANCH
+#            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+#             echo "!after if"
+#          fi
           
 
-      - name: Check out Everest catalog
-        uses: actions/checkout@v4
-        with:
-          repository: percona/everest-catalog
-          ref: 'main'
-          path: everest-catalog
-          token: ${{ secrets.ROBOT_TOKEN }}
+#      - name: Check out Everest catalog
+#        uses: actions/checkout@v4
+#        with:
+#          repository: percona/everest-catalog
+#          ref: 'main'
+#          path: everest-catalog
+#          token: ${{ secrets.ROBOT_TOKEN }}
+#
+#      - name: Check out Everest catalog RC-branch
+#        run: |
+#          cd everest-catalog
+#          # Check if the branch already exists
+#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+#          EXIT_CODE=$?
+#
+#          if [[ $EXIT_CODE != '0' ]]; then
+#            git checkout -b $RC_BRANCH
+#            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+#          fi
 
-      - name: Check out Everest catalog RC-branch
-        run: |
-          cd everest-catalog
-          # Check if the branch already exists
-          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          EXIT_CODE=$?
 
-          if [[ $EXIT_CODE != '0' ]]; then
-            git checkout -b $RC_BRANCH
-            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
-          fi
-
-
-      - name: Check out Everest frontend
-        uses: actions/checkout@v4
-        with:
-          repository: percona/percona-everest-frontend
-          ref: 'main'
-          path: percona-everest-frontend
-          token: ${{ secrets.ROBOT_TOKEN }}
-
-      - name: Check out Everest Frontend RC-branch
-        run: |
-          cd percona-everest-frontend
-
-          # Check if the branch already exists
-          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-          EXIT_CODE=$?
-
-          if [[ $EXIT_CODE != '0' ]]; then
-            git checkout -b $RC_BRANCH
-            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
-          else
-            git checkout $RC_BRANCH
-          fi
-
-      - name: Run with Node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install Bit Version Manager
-        run: npm i -g @teambit/bvm
-
-      - name: Install latest Bit version
-        run: bvm install 0.2.3
-
-      - name: Add bvm bin folder to path
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Set up bit config
-        env:
-          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-        run: bit config set user.token $BIT_TOKEN
-
-      - name: Build Everest Frontend app
-        run: |
-          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-          bit install --recurring-install
-          bit snap
-          bit artifacts percona.apps/everest --out-dir build
-          mkdir ${GITHUB_WORKSPACE}/front
-          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+#      - name: Check out Everest frontend
+#        uses: actions/checkout@v4
+#        with:
+#          repository: percona/percona-everest-frontend
+#          ref: 'main'
+#          path: percona-everest-frontend
+#          token: ${{ secrets.ROBOT_TOKEN }}
+#
+#      - name: Check out Everest Frontend RC-branch
+#        run: |
+#          cd percona-everest-frontend
+#
+#          # Check if the branch already exists
+#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+#          EXIT_CODE=$?
+#
+#          if [[ $EXIT_CODE != '0' ]]; then
+#            git checkout -b $RC_BRANCH
+#            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+#          else
+#            git checkout $RC_BRANCH
+#          fi
+#
+#      - name: Run with Node 16
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#
+#      - name: Install Bit Version Manager
+#        run: npm i -g @teambit/bvm
+#
+#      - name: Install latest Bit version
+#        run: bvm install 0.2.3
+#
+#      - name: Add bvm bin folder to path
+#        run: echo "$HOME/bin" >> $GITHUB_PATH
+#
+#      - name: Set up bit config
+#        env:
+#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+#        run: bit config set user.token $BIT_TOKEN
+#
+#      - name: Build Everest Frontend app
+#        run: |
+#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+#          bit install --recurring-install
+#          bit snap
+#          bit artifacts percona.apps/everest --out-dir build
+#          mkdir ${GITHUB_WORKSPACE}/front
+#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -167,28 +167,28 @@ jobs:
             git checkout $RC_BRANCH
           fi
 
-      - name: Embed Everest Frontend app into backend
-        run: |
-          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-          cd ${GITHUB_WORKSPACE}/backend
+#      - name: Embed Everest Frontend app into backend
+#        run: |
+#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+#          cd ${GITHUB_WORKSPACE}/backend
 
-      - name: Setup docker build metadata
-        uses: docker/metadata-action@v4
-        id: meta
-        with:
-          images: perconalab/everest
-          tags: ${{ env.VERSION }}
-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and Push everest RC-image
-        uses: docker/build-push-action@v4
-        with:
-          context: backend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+#      - name: Setup docker build metadata
+#        uses: docker/metadata-action@v4
+#        id: meta
+#        with:
+#          images: perconalab/everest
+#          tags: ${{ env.VERSION }}
+#
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and Push everest RC-image
+#        uses: docker/build-push-action@v4
+#        with:
+#          context: backend
+#          push: true
+#          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -123,7 +123,7 @@ jobs:
             git commit -a -m "update version tag"
             git push origin $RC_BRANCH
           else
-            git fetch && git checkout $RC_BRANCH
+            git checkout $RC_BRANCH
           fi
 
       - name: Embed Everest Frontend app into backend

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -27,7 +27,7 @@ jobs:
           fi
       - name: Define release branch
         run: |
-          echo ${VERSION#v} >> $GITHUB_ENV
+          echo "release-${VERSION#v}" >> $GITHUB_ENV
 
       - name: Print RC_BRANCH
         run: echo $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -78,6 +78,7 @@ jobs:
 #
       - name: Check out Everest Backend
         run: |
+          cd percona-everest-backend
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH origin/main

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: A release version in v*.*.* format
+        description: The release version in v*.*.* format
         required: true
   push:
     branches:
@@ -14,8 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      #VERSION: ${{ github.event.inputs.version }}
-      VERSION: v100.100.100
+      #VERSION: ${{ github.event.inputs.version }}  # <-- UNCOMMENT ME
+      VERSION: v100.100.100  # <-- DELETE ME
       RC_BRANCH: ''
     steps:
       - name: Validate input
@@ -34,110 +34,7 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
-#      - name: Check out frontend repo
-#        uses: actions/checkout@v4
-#        with:
-#          repository: percona/percona-everest-frontend
-#          ref: 'main'
-#          path: percona-everest-frontend
-#          token: ${{ secrets.ROBOT_TOKEN }}
-#          run: |
-#            cd percona-everest-frontend
-#
-#            # Check if the branch already exists
-#            if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-#              git checkout -b $RC_BRANCH origin/main
-#            else
-#              git checkout $RC_BRANCH
-#            fi
-
-#      - name: Run with Node 16
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: ${{ matrix.node-version }}
-#
-#      - name: Install Bit Version Manager
-#        run: npm i -g @teambit/bvm
-#
-#      - name: Install latest Bit version
-#        run: bvm install 0.2.3
-#
-#      - name: Add bvm bin folder to path
-#        run: echo "$HOME/bin" >> $GITHUB_PATH
-#
-#      - name: Set up bit config
-#        env:
-#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-#        run: bit config set user.token $BIT_TOKEN
-#
-#      - name: Build Everest Frontend app
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-#          bit install --recurring-install
-#          bit snap
-#          bit artifacts percona.apps/everest --out-dir build
-#          mkdir ${GITHUB_WORKSPACE}/front
-#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
-#
-
-      - name: Check out Everest Backend
-        uses: actions/checkout@v4
-        with:
-          path: ./backend
-          ref: 'main'
-
-      - name: Check out rc-branch
-        run: |
-          cd backend
-          # Check if the branch already exists
-          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-            git checkout -b $RC_BRANCH
-            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
-            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
-            git config --global user.email "oksana.grishchenko@percona.com"
-            git config --global user.name "Percona Robot"
-            git commit -a -m "update version tag"
-            git push origin $RC_BRANCH
-          else
-            git checkout $RC_BRANCH
-          fi
-
-#      - name: Embed Everest Frontend app into backend
-#        run: |
-#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-#          cd ${GITHUB_WORKSPACE}/backend
-#
-#      - name: Set tag from inputs
-#        run: echo "IMAGE_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-#        if: ${{ github.event.inputs.tag != '' }}
-#
-#      - name: Set tag from inputs
-#        run: echo "IMAGE_TAG=dev-latest" >> $GITHUB_ENV
-#        if: ${{ github.event.inputs.tag == '' }}
-#
-#      - name: Setup docker build metadata
-#        uses: docker/metadata-action@v4
-#        id: meta
-#        with:
-#          images: perconalab/everest
-#          tags: ${{ env.IMAGE_TAG }}
-#
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v2
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build and Push everest dev-latest image
-#        uses: docker/build-push-action@v4
-#        with:
-#          context: backend
-#          push: true
-#          tags: ${{ steps.meta.outputs.tags }}
-
-
-      - name: Check out EVEREST CLI
+      - name: Check out Everest CLI
         uses: actions/checkout@v4
         with:
           repository: percona/percona-everest-cli
@@ -146,7 +43,7 @@ jobs:
           token: ${{ secrets.ROBOT_TOKEN }}
 
 
-      - name: Check out rc-branch
+      - name: Check out Everest CLI RC-branch
         run: |
           cd percona-everest-cli
           # Check if the branch already exists
@@ -156,3 +53,103 @@ jobs:
           else
             git checkout $RC_BRANCH
           fi
+
+
+      - name: Check out Everest frontend
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-frontend
+          ref: 'main'
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+#      - name: Check out Everest Frontend RC-branch
+#        run: |
+#          cd percona-everest-frontend
+#
+#          # Check if the branch already exists
+#          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+#            git checkout -b $RC_BRANCH origin/main
+#          else
+#            git checkout $RC_BRANCH
+#          fi
+
+      - name: Run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Build Everest Frontend app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+
+      - name: Check out Everest Backend
+        uses: actions/checkout@v4
+        with:
+          path: ./backend
+          ref: 'main'
+
+#      - name: Check out rc-branch
+#        run: |
+#          cd backend
+#          # Check if the branch already exists
+#          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+#            git checkout -b $RC_BRANCH
+#            # update tag refs in scripts
+#            sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+#            git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+#            # configure userdata for commits
+#            git config --global user.email "oksana.grishchenko@percona.com"
+#            git config --global user.name "Everest RC CI"
+#            git commit -a -m "update version tag"
+#            git push origin $RC_BRANCH
+#          else
+#            git checkout $RC_BRANCH
+#          fi
+
+      - name: Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
+
+      - name: Setup docker build metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: perconalab/everest
+          tags: ${{ env.VERSION }}
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push everest RC-image
+        uses: docker/build-push-action@v4
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
       - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
-      - rc-test                      # <-- DELETE ME before merge
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -44,64 +43,71 @@ jobs:
           token: ${{ secrets.ROBOT_TOKEN }}
 
 
-#      - name: Check out Everest CLI RC-branch
-#        run: |
-#          cd percona-everest-cli
-#          # Check if the branch already exists
-#          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-#            git checkout -b $RC_BRANCH
-#            git push origin $RC_BRANCH
-#          else
-#            git checkout $RC_BRANCH
-#          fi
+      - name: Check out Everest CLI RC-branch
+        run: |
+          cd percona-everest-cli
+          # Check if the branch already exists
+          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+          
+          if [[ $EXIT_CODE != '0' ]]; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH
+          else
+            git checkout $RC_BRANCH
+          fi
 
 
-#      - name: Check out Everest frontend
-#        uses: actions/checkout@v4
-#        with:
-#          repository: percona/percona-everest-frontend
-#          ref: 'main'
-#          path: percona-everest-frontend
-#          token: ${{ secrets.ROBOT_TOKEN }}
+      - name: Check out Everest frontend
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-frontend
+          ref: 'main'
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
 
-#      - name: Check out Everest Frontend RC-branch
-#        run: |
-#          cd percona-everest-frontend
-#
-#          # Check if the branch already exists
-#          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
-#            git checkout -b $RC_BRANCH origin/main
-#          else
-#            git checkout $RC_BRANCH
-#          fi
+      - name: Check out Everest Frontend RC-branch
+        run: |
+          cd percona-everest-frontend
 
-#      - name: Run with Node 16
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: ${{ matrix.node-version }}
-#
-#      - name: Install Bit Version Manager
-#        run: npm i -g @teambit/bvm
-#
-#      - name: Install latest Bit version
-#        run: bvm install 0.2.3
-#
-#      - name: Add bvm bin folder to path
-#        run: echo "$HOME/bin" >> $GITHUB_PATH
-#
-#      - name: Set up bit config
-#        env:
-#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-#        run: bit config set user.token $BIT_TOKEN
-#
-#      - name: Build Everest Frontend app
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-#          bit install --recurring-install
-#          bit snap
-#          bit artifacts percona.apps/everest --out-dir build
-#          mkdir ${GITHUB_WORKSPACE}/front
-#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+          # Check if the branch already exists
+          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+          
+          if [[ $EXIT_CODE != '0' ]]; then
+            git checkout -b $RC_BRANCH 
+            git push origin $RC_BRANCH
+          else
+            git checkout $RC_BRANCH
+          fi
+
+      - name: Run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Build Everest Frontend app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -113,12 +119,10 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
           EXIT_CODE=$?
           
           if [[ $EXIT_CODE != '0' ]]; then
-          
-          #if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH
             # update tag refs in scripts
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
@@ -132,10 +136,10 @@ jobs:
             git checkout $RC_BRANCH
           fi
 
-#      - name: Embed Everest Frontend app into backend
-#        run: |
-#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-#          cd ${GITHUB_WORKSPACE}/backend
+      - name: Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
 
       - name: Setup docker build metadata
         uses: docker/metadata-action@v4
@@ -157,5 +161,3 @@ jobs:
           context: backend
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-
-

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       #VERSION: ${{ github.event.inputs.version }}
       VERSION: v100.100.100
-      RC_BRANCH: ''
+      RC_BRANCH: release-${VERSION#v}
     steps:
       - name: Validate input
         run: |
@@ -25,9 +25,9 @@ jobs:
             echo "Wrong version format provided, please use v*.*.* format" 
             exit 1
           fi
-      - name: Define release branch
-        run: |
-          echo "release-${VERSION#v}" >> $GITHUB_ENV
+#      - name: Define release branch
+#        run: |
+#          echo "release-${VERSION#v}" >> $GITHUB_ENV
 
       - name: Print RC_BRANCH
         run: echo $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -78,7 +78,7 @@ jobs:
 #
       - name: Check out Everest Backend
         run: |
-          cd percona-everest-backend
+          ls -a
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH origin/main

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -78,6 +78,7 @@ jobs:
 #
       - name: Check out Everest Backend
         run: |
+          cd ..
           ls -a
           # Check if the branch already exists
           if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -51,96 +51,90 @@ jobs:
           path: percona-everest-cli
           token: ${{ secrets.ROBOT_TOKEN }}
 
-#      - name: Check out Everest CLI RC-branch
-#        run: |
-#          cd percona-everest-cli
-#          # Check if the branch already exists
-#          echo "!fetch"
-#          git fetch
-#           echo "!ls-remote"
-#          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-#          echo "!exit code"
-#          EXIT_CODE=$?
-#          echo "!before if"
-#          if [[ $EXIT_CODE == '2' ]]; then
-#            echo "!in if"
-#            git checkout -b $RC_BRANCH
-#            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
-#             echo "!after if"
-#          fi
+      - name: Check out Everest CLI RC-branch
+        run: |
+          cd percona-everest-cli
+          # Check if the branch already exists
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          
+          if [[ -z ${check_branch} ]]; then
+            git checkout -b $RC_BRANCH
+            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+          fi
           
 
-#      - name: Check out Everest catalog
-#        uses: actions/checkout@v4
-#        with:
-#          repository: percona/everest-catalog
-#          ref: 'main'
-#          path: everest-catalog
-#          token: ${{ secrets.ROBOT_TOKEN }}
-#
-#      - name: Check out Everest catalog RC-branch
-#        run: |
-#          cd everest-catalog
-#          # Check if the branch already exists
-#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-#          EXIT_CODE=$?
-#
-#          if [[ $EXIT_CODE != '0' ]]; then
-#            git checkout -b $RC_BRANCH
-#            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
-#          fi
+      - name: Check out Everest catalog
+        uses: actions/checkout@v4
+        with:
+          repository: percona/everest-catalog
+          ref: 'main'
+          path: everest-catalog
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Check out Everest catalog RC-branch
+        run: |
+          cd everest-catalog
+          # Check if the branch already exists
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          
+          if [[ -z ${check_branch} ]]; then
+            git checkout -b $RC_BRANCH
+            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+          fi
 
 
-#      - name: Check out Everest frontend
-#        uses: actions/checkout@v4
-#        with:
-#          repository: percona/percona-everest-frontend
-#          ref: 'main'
-#          path: percona-everest-frontend
-#          token: ${{ secrets.ROBOT_TOKEN }}
-#
-#      - name: Check out Everest Frontend RC-branch
-#        run: |
-#          cd percona-everest-frontend
-#
-#          # Check if the branch already exists
-#          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
-#          EXIT_CODE=$?
-#
-#          if [[ $EXIT_CODE != '0' ]]; then
-#            git checkout -b $RC_BRANCH
-#            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
-#          else
-#            git checkout $RC_BRANCH
-#          fi
-#
-#      - name: Run with Node 16
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: ${{ matrix.node-version }}
-#
-#      - name: Install Bit Version Manager
-#        run: npm i -g @teambit/bvm
-#
-#      - name: Install latest Bit version
-#        run: bvm install 0.2.3
-#
-#      - name: Add bvm bin folder to path
-#        run: echo "$HOME/bin" >> $GITHUB_PATH
-#
-#      - name: Set up bit config
-#        env:
-#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-#        run: bit config set user.token $BIT_TOKEN
-#
-#      - name: Build Everest Frontend app
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-#          bit install --recurring-install
-#          bit snap
-#          bit artifacts percona.apps/everest --out-dir build
-#          mkdir ${GITHUB_WORKSPACE}/front
-#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+      - name: Check out Everest frontend
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-frontend
+          ref: 'main'
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Check out Everest Frontend RC-branch
+        run: |
+          cd percona-everest-frontend
+
+          # Check if the branch already exists
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          
+          if [[ -z ${check_branch} ]]; then
+            git checkout -b $RC_BRANCH
+            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+          else
+            git checkout $RC_BRANCH
+          fi
+
+      - name: Run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Build Everest Frontend app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -162,33 +156,33 @@ jobs:
             git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             # configure userdata for commits
             git commit -a -m "update version tag"
-            git push origin $RC_BRANCH   
+            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
           else
             git checkout $RC_BRANCH
           fi
 
-#      - name: Embed Everest Frontend app into backend
-#        run: |
-#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-#          cd ${GITHUB_WORKSPACE}/backend
+      - name: Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
 
-#      - name: Setup docker build metadata
-#        uses: docker/metadata-action@v4
-#        id: meta
-#        with:
-#          images: perconalab/everest
-#          tags: ${{ env.VERSION }}
-#
-#
-#      - name: Login to GitHub Container Registry
-#        uses: docker/login-action@v2
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build and Push everest RC-image
-#        uses: docker/build-push-action@v4
-#        with:
-#          context: backend
-#          push: true
-#          tags: ${{ steps.meta.outputs.tags }}
+      - name: Setup docker build metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: perconalab/everest
+          tags: ${{ env.VERSION }}
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push everest RC-image
+        uses: docker/build-push-action@v4
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -4,16 +4,119 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: A release version in vX.Y.Z format
+        description: A release version in v*.*.* format
         required: true
   push:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
+      - rc-test # <-- DELETE ME
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      RC_BRANCH: release-${{ github.event.inputs.version#v }}
     steps:
+      - name: Validate input
+        run: |
+          echo $RC_BRANCH
+          if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Wrong version format provided, please use v*.*.* format" 
+            exit 1
+          fi
+
       - name: Configure git for private modules
         env:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
+
+      - name: Check out frontend repo
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-frontend
+          ref: 'main'
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
+          run: |
+            cd percona-everest-frontend
+          
+            # Check if the branch already exists
+            if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+              git checkout -b $RC_BRANCH origin/main
+            else
+              git checkout $RC_BRANCH
+            fi
+
+#      - name: Run with Node 16
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#
+#      - name: Install Bit Version Manager
+#        run: npm i -g @teambit/bvm
+#
+#      - name: Install latest Bit version
+#        run: bvm install 0.2.3
+#
+#      - name: Add bvm bin folder to path
+#        run: echo "$HOME/bin" >> $GITHUB_PATH
+#
+#      - name: Set up bit config
+#        env:
+#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+#        run: bit config set user.token $BIT_TOKEN
+#
+#      - name: Build Everest Frontend app
+#        run: |
+#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+#          bit install --recurring-install
+#          bit snap
+#          bit artifacts percona.apps/everest --out-dir build
+#          mkdir ${GITHUB_WORKSPACE}/front
+#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+#
+      - name: Check out Everest Backend
+        uses: actions/checkout@v4
+        with:
+          path: ./backend
+        run: |
+          # Check if the branch already exists
+          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+            git checkout -b $RC_BRANCH origin/main
+          else
+            git checkout $RC_BRANCH
+          fi
+#
+#      - name: Embed Everest Frontend app into backend
+#        run: |
+#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+#          cd ${GITHUB_WORKSPACE}/backend
+#
+#      - name: Set tag from inputs
+#        run: echo "IMAGE_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+#        if: ${{ github.event.inputs.tag != '' }}
+#
+#      - name: Set tag from inputs
+#        run: echo "IMAGE_TAG=dev-latest" >> $GITHUB_ENV
+#        if: ${{ github.event.inputs.tag == '' }}
+#
+#      - name: Setup docker build metadata
+#        uses: docker/metadata-action@v4
+#        id: meta
+#        with:
+#          images: perconalab/everest
+#          tags: ${{ env.IMAGE_TAG }}
+#
+#
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and Push everest dev-latest image
+#        uses: docker/build-push-action@v4
+#        with:
+#          context: backend
+#          push: true
+#          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
       - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
+      - rc-test                     # <-- DELETE ME before merge
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -62,7 +62,7 @@ jobs:
           echo "!exit code"
           EXIT_CODE=$?
           echo "!before if"
-          if [[ $EXIT_CODE != '0' ]]; then
+          if [[ $EXIT_CODE == '2' ]]; then
             echo "!in if"
             git checkout -b $RC_BRANCH
             # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
       - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
-      - rc-test2                     # <-- DELETE ME before merge
 
 jobs:
   build:

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -154,6 +154,7 @@ jobs:
           # Check if the branch already exists
           git fetch
           check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          echo $check_branch
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -9,13 +9,13 @@ on:
   push:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
-      - rc-test # <-- DELETE ME
+      - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      #VERSION: ${{ github.event.inputs.version }}  # <-- UNCOMMENT ME
-      VERSION: v100.100.100  # <-- DELETE ME
+      #VERSION: ${{ github.event.inputs.version }}  # <-- UNCOMMENT ME before merge
+      VERSION: v100.100.100                         # <-- DELETE ME before merge
       RC_BRANCH: ''
     steps:
       - name: Validate input
@@ -112,7 +112,12 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
+          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          EXIT_CODE=$?
+          
+          if [[ $EXIT_CODE == '0' ]]; then
+          
+          #if ! git rev-parse --verify --quiet "refs/heads/$RC_BRANCH"; then
             git checkout -b $RC_BRANCH
             # update tag refs in scripts
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
       - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
+      - rc-test2                     # <-- DELETE ME before merge
 
 jobs:
   build:
@@ -54,12 +55,19 @@ jobs:
         run: |
           cd percona-everest-cli
           # Check if the branch already exists
-          git fetch && git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          echo "!fetch"
+          git fetch 
+           echo "!ls-remote"
+          git ls-remote --exit-code --heads origin $RC_BRANCH >/dev/null 2>&1
+          echo "!exit code"
           EXIT_CODE=$?
-
+          echo "!before if"
           if [[ $EXIT_CODE != '0' ]]; then
+            echo "!in if"
             git checkout -b $RC_BRANCH
             # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+             echo "!after if"
+          fi
           
 
       - name: Check out Everest catalog
@@ -80,6 +88,7 @@ jobs:
           if [[ $EXIT_CODE != '0' ]]; then
             git checkout -b $RC_BRANCH
             # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+          fi
 
 
       - name: Check out Everest frontend

--- a/.github/workflows/rc_create.yml
+++ b/.github/workflows/rc_create.yml
@@ -113,8 +113,8 @@ jobs:
             sed -i "s/dev-latest/$RC_BRANCH/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
             
             # configure userdata for commits
-            git config --global user.email "oksana.grishchenko@percona.com"
-            git config --global user.name "Everest RC CI"
+            git config --global user.email "everest-ci@percona.com"
+            git config --global user.name "Everest RC CI triggered by ${{ github.actor }}"
             
             # commit and push the updated files
             git commit -a -m "update version tag"

--- a/.github/workflows/rc_create.yml
+++ b/.github/workflows/rc_create.yml
@@ -1,4 +1,4 @@
-name: Build and push RC image
+name: Create RC branches
 
 on:
   workflow_dispatch:
@@ -6,17 +6,12 @@ on:
       version:
         description: The release version in v*.*.* format
         required: true
-  push:
-    branches:
-      - release-[0-9]+.[0-9]+.[0-9]+*
-      - EVEREST-428-rc-pipeline                      # <-- DELETE ME before merge
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      #VERSION: ${{ github.event.inputs.version }}  # <-- UNCOMMENT ME before merge
-      VERSION: v100.100.100                         # <-- DELETE ME before merge
+      VERSION: ${{ github.event.inputs.version }}
       RC_BRANCH: ''
     steps:
       - name: Validate input
@@ -43,7 +38,7 @@ jobs:
           path: percona-everest-cli
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Check out Everest CLI RC-branch
+      - name: Create Everest CLI RC-branch
         run: |
           cd percona-everest-cli
           # Check if the branch already exists
@@ -52,7 +47,7 @@ jobs:
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH
-            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+            git push origin $RC_BRANCH   
           fi
           
 
@@ -64,7 +59,7 @@ jobs:
           path: everest-catalog
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Check out Everest catalog RC-branch
+      - name: Create Everest catalog RC-branch
         run: |
           cd everest-catalog
           # Check if the branch already exists
@@ -73,7 +68,7 @@ jobs:
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH
-            # git push origin $RC_BRANCH    <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
+            git push origin $RC_BRANCH    
           fi
 
 
@@ -85,7 +80,7 @@ jobs:
           path: percona-everest-frontend
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Check out Everest Frontend RC-branch
+      - name: Create Everest Frontend RC-branch
         run: |
           cd percona-everest-frontend
 
@@ -95,38 +90,8 @@ jobs:
           
           if [[ -z ${check_branch} ]]; then
             git checkout -b $RC_BRANCH
-            # git push origin $RC_BRANCH   <--- UNCOMMENT ME once the permission granted to ROBOT_TOKEN
-          else
-            git checkout $RC_BRANCH
+            git push origin $RC_BRANCH   
           fi
-
-      - name: Run with Node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install Bit Version Manager
-        run: npm i -g @teambit/bvm
-
-      - name: Install latest Bit version
-        run: bvm install 0.2.3
-
-      - name: Add bvm bin folder to path
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Set up bit config
-        env:
-          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-        run: bit config set user.token $BIT_TOKEN
-
-      - name: Build Everest Frontend app
-        run: |
-          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-          bit install --recurring-install
-          bit snap
-          bit artifacts percona.apps/everest --out-dir build
-          mkdir ${GITHUB_WORKSPACE}/front
-          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -134,7 +99,7 @@ jobs:
           path: ./backend
           ref: 'main'
 
-      - name: Check out Everest Backend rc-branch
+      - name: Create and update Everest Backend RC-branch
         run: |
           cd backend
           # Check if the branch already exists
@@ -154,32 +119,4 @@ jobs:
             # commit and push the updated files
             git commit -a -m "update version tag"
             git push origin $RC_BRANCH  
-          else
-            git checkout $RC_BRANCH
           fi
-
-      - name: Embed Everest Frontend app into backend
-        run: |
-          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-          cd ${GITHUB_WORKSPACE}/backend
-
-      - name: Setup docker build metadata
-        uses: docker/metadata-action@v4
-        id: meta
-        with:
-          images: perconalab/everest
-          tags: ${{ env.VERSION }}
-
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and Push everest RC-image
-        uses: docker/build-push-action@v4
-        with:
-          context: backend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/rc_rebuild.yml
+++ b/.github/workflows/rc_rebuild.yml
@@ -1,0 +1,95 @@
+name: Build and push RC image
+
+on:
+  push:
+    branches:
+      - release-[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ''
+      RELEASE_BRANCH_NAME: ''
+    steps:
+      - name: Define release branch name
+        run: |
+          echo "RELEASE_BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Define version name
+        run: |
+          semantic_version=${RELEASE_BRANCH_NAME#"release-"}
+          echo "VERSION=v${semantic_version}" >> $GITHUB_ENV
+
+      - name: Configure git for private modules
+        env:
+          ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
+        run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
+
+      - name: Check out Everest frontend
+        uses: actions/checkout@v4
+        with:
+          ref: $ {{ env.RELEASE_BRANCH_NAME }}
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Build Everest Frontend app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+
+      - name: Check out Everest Backend
+        uses: actions/checkout@v4
+        with:
+          path: ./backend
+          ref: $ {{ env.RELEASE_BRANCH_NAME }}
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
+
+      - name: Setup docker build metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: perconalab/everest
+          tags: ${{ env.VERSION }}
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push everest RC-image
+        uses: docker/build-push-action@v4
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
[![EVEREST-428](https://badgen.net/badge/JIRA/EVEREST-428/green)](https://jira.percona.com/browse/EVEREST-428) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**RC pipleline**
---
**Problem:**
EVEREST-428

Everest needs a workflow for building release branches.

**Solution:**
Create a manually triggering workflow. It would accept the version we want to create the RC for and would create the `release-*.*.*` branches in the backend, cli, frontend and catalog repos. It will update tags in the deployment scripts (so no manual intervention needed to run it from the rc-branch), build and push the new image to the registry. 