### PR TITLE
EVEREST-256 Improved validation of database cluster CR

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - goerr113           # not useful after migration to the standard errors
     - exhaustruct      # not useful
     - exhaustivestruct # annoying and duplicates exhaustruct
     - godox            # fails to be nolint-ed when necessary

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,6 @@ linters-settings:
         - $all
         - "!$test"
         deny:
-          - pkg: errors
-            desc: use "github.com/pkg/errors" instead
           - pkg: github.com/gogo/protobuf/proto
             desc: use "github.com/golang/protobuf/proto" instead
 

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -42,6 +42,10 @@ func (e *EverestServer) CreateDatabaseCluster(ctx echo.Context, kubernetesID str
 		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
 	}
 
+	if err := e.validateDatabaseClusterCR(ctx, kubernetesID, dbc); err != nil {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
+	}
+
 	_, kubeClient, code, err := e.initKubeClient(ctx.Request().Context(), kubernetesID)
 	if err != nil {
 		return ctx.JSON(code, Error{Message: pointer.ToString(err.Error())})

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -134,6 +134,10 @@ func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID str
 		})
 	}
 
+	if err := e.validateDatabaseClusterCR(ctx, kubernetesID, dbc); err != nil {
+		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
+	}
+
 	_, kubeClient, code, err := e.initKubeClient(ctx.Request().Context(), kubernetesID)
 	if err != nil {
 		return ctx.JSON(code, Error{Message: pointer.ToString(err.Error())})

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -125,7 +125,7 @@ func (e *EverestServer) GetDatabaseCluster(ctx echo.Context, kubernetesID string
 }
 
 // UpdateDatabaseCluster replaces the specified database cluster on the specified kubernetes cluster.
-func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID string, name string) error { //nolint:funlen
+func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID string, name string) error { //nolint:funlen,cyclop
 	dbc := &DatabaseCluster{}
 	if err := e.getBodyFromContext(ctx, dbc); err != nil {
 		e.l.Error(err)

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -38,10 +38,6 @@ func (e *EverestServer) CreateDatabaseCluster(ctx echo.Context, kubernetesID str
 		})
 	}
 
-	if err := validateCreateDatabaseClusterRequest(*dbc); err != nil {
-		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
-	}
-
 	if err := e.validateDatabaseClusterCR(ctx, kubernetesID, dbc); err != nil {
 		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
 	}

--- a/api/validation.go
+++ b/api/validation.go
@@ -356,15 +356,8 @@ func (e *EverestServer) validateDatabaseClusterCR(ctx echo.Context, kubernetesID
 		}
 	}
 	if databaseCluster.Spec.Proxy.Type != nil {
-		if databaseCluster.Spec.Engine.Type == engineTypePXC && (*databaseCluster.Spec.Proxy.Type != "proxysql" || *databaseCluster.Spec.Proxy.Type != "haproxy") {
-			return errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters")
-		}
-
-		if databaseCluster.Spec.Engine.Type == engineTypePG && *databaseCluster.Spec.Proxy.Type != "pgbouncer" {
-			return errors.New("You can use only PGBouncer as a proxy type for Postgres clusters")
-		}
-		if databaseCluster.Spec.Engine.Type == engineTypePSMDB && *databaseCluster.Spec.Proxy.Type != "mongos" {
-			return errors.New("You can use only Mongos as a proxy type for MongoDB clusters")
+		if err := validateProxy(databaseCluster.Spec.Engine.Type, string(*databaseCluster.Spec.Proxy.Type)); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -380,4 +373,18 @@ func containsVersion(version string, versions []string) bool {
 		}
 	}
 	return false
+}
+
+func validateProxy(engineType, proxyType string) error {
+	if engineType == engineTypePXC && (proxyType != "proxysql" || proxyType != "haproxy") {
+		return errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters")
+	}
+
+	if engineType == engineTypePG && proxyType != "pgbouncer" {
+		return errors.New("You can use only PGBouncer as a proxy type for Postgres clusters")
+	}
+	if engineType == engineTypePSMDB && proxyType != "mongos" {
+		return errors.New("You can use only Mongos as a proxy type for MongoDB clusters")
+	}
+	return nil
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -396,16 +396,16 @@ func containsVersion(version string, versions []string) bool {
 }
 
 func validateProxy(engineType, proxyType string) error {
-	if engineType == engineTypePXC {
-		if proxyType != "proxysql" && proxyType != "haproxy" {
+	if engineType == everestv1alpha1.DatabaseEnginePXC {
+		if proxyType != everestv1alpha1.ProxyTypeProxySQL && proxyType != everestv1alpha1.ProxyTypeHAProxy {
 			return errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters") //nolint:stylecheck
 		}
 	}
 
-	if engineType == engineTypePG && proxyType != "pgbouncer" {
+	if engineType == everestv1alpha1.DatabaseEnginePostgresql && proxyType != everestv1alpha1.ProxyTypePGBouncer {
 		return errors.New("You can use only PGBouncer as a proxy type for Postgres clusters") //nolint:stylecheck
 	}
-	if engineType == engineTypePSMDB && proxyType != "mongos" {
+	if engineType == everestv1alpha1.DatabaseEnginePSMDB && proxyType != everestv1alpha1.ProxyTypeMongos {
 		return errors.New("You can use only Mongos as a proxy type for MongoDB clusters") //nolint:stylecheck
 	}
 	return nil

--- a/api/validation.go
+++ b/api/validation.go
@@ -446,7 +446,7 @@ func validateBackupSpec(cluster *DatabaseCluster) error {
 }
 
 func validateResourceLimits(cluster *DatabaseCluster) error {
-	if err := ensureNotEmptySpec(cluster); err != nil {
+	if err := ensureNonEmptyResources(cluster); err != nil {
 		return err
 	}
 	if err := validateCPU(cluster); err != nil {
@@ -458,7 +458,7 @@ func validateResourceLimits(cluster *DatabaseCluster) error {
 	return validateStorageSize(cluster)
 }
 
-func ensureNotEmptySpec(cluster *DatabaseCluster) error {
+func ensureNonEmptyResources(cluster *DatabaseCluster) error {
 	if cluster.Spec.Engine.Resources == nil {
 		return errNoResourceDefined
 	}

--- a/api/validation.go
+++ b/api/validation.go
@@ -406,6 +406,24 @@ func validateProxy(engineType, proxyType string) error {
 }
 
 func validateBackupSpec(cluster *DatabaseCluster) error {
+	if cluster.Spec.Backup == nil {
+		return nil
+	}
+	if !cluster.Spec.Backup.Enabled {
+		return nil
+	}
+	if cluster.Spec.Backup.Schedules == nil {
+		return errors.New("Please specify at lease one backup schedule")
+	}
+
+	for _, schedule := range *cluster.Spec.Backup.Schedules {
+		if schedule.Name == "" {
+			return errors.New("'name' field cannot be empty")
+		}
+		if schedule.Enabled && schedule.BackupStorageName == "" {
+			return errors.New("'backupStorageName' field cannot be empty when schedule is enabled")
+		}
+	}
 	return nil
 }
 func validateResourceLimits(cluster *DatabaseCluster) error {

--- a/api/validation.go
+++ b/api/validation.go
@@ -45,13 +45,16 @@ const (
 )
 
 var (
-	errDBCEmptyMetadata   = errors.New("DatabaseCluster's Metadata should not be empty")
-	errDBCNameEmpty       = errors.New("DatabaseCluster's metadata.name should not be empty")
-	errDBCNameWrongFormat = errors.New("DatabaseCluster's metadata.name should be a string")
-	errNotEnoughMemory    = errors.New("Memory limits should be above 512M")                                                             //nolint:stylecheck
-	errInt64NotSupported  = errors.New("Specifying resources using int64 data type is not supported. Please use string format for that") //nolint:stylecheck
-	errNotEnoughCPU       = errors.New("CPU limits should be above 600m")                                                                //nolint:stylecheck
-	errNotEnoughDiskSize  = errors.New("Storage size should be above 1G")                                                                //nolint:stylecheck
+	errDBCEmptyMetadata      = errors.New("DatabaseCluster's Metadata should not be empty")
+	errDBCNameEmpty          = errors.New("DatabaseCluster's metadata.name should not be empty")
+	errDBCNameWrongFormat    = errors.New("DatabaseCluster's metadata.name should be a string")
+	errNotEnoughMemory       = errors.New("Memory limits should be above 512M")                                                             //nolint:stylecheck
+	errInt64NotSupported     = errors.New("Specifying resources using int64 data type is not supported. Please use string format for that") //nolint:stylecheck
+	errNotEnoughCPU          = errors.New("CPU limits should be above 600m")                                                                //nolint:stylecheck
+	errNotEnoughDiskSize     = errors.New("Storage size should be above 1G")                                                                //nolint:stylecheck
+	errUnsupportedPXCProxy   = errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters")                                  //nolint:stylecheck
+	errUnsupportedPGProxy    = errors.New("You can use only PGBouncer as a proxy type for Postgres clusters")                               //nolint:stylecheck
+	errUnsupportedPSMDBProxy = errors.New("You can use only Mongos as a proxy type for MongoDB clusters")                                   //nolint:stylecheck
 	//nolint:gochecknoglobals
 	operatorEngine = map[everestv1alpha1.EngineType]string{
 		everestv1alpha1.DatabaseEnginePXC:        pxcDeploymentName,
@@ -399,15 +402,15 @@ func containsVersion(version string, versions []string) bool {
 func validateProxy(engineType, proxyType string) error {
 	if engineType == string(everestv1alpha1.DatabaseEnginePXC) {
 		if proxyType != string(everestv1alpha1.ProxyTypeProxySQL) && proxyType != string(everestv1alpha1.ProxyTypeHAProxy) {
-			return errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters") //nolint:stylecheck
+			return errUnsupportedPXCProxy
 		}
 	}
 
 	if engineType == string(everestv1alpha1.DatabaseEnginePostgresql) && proxyType != string(everestv1alpha1.ProxyTypePGBouncer) {
-		return errors.New("You can use only PGBouncer as a proxy type for Postgres clusters") //nolint:stylecheck
+		return errUnsupportedPGProxy
 	}
 	if engineType == string(everestv1alpha1.DatabaseEnginePSMDB) && proxyType != string(everestv1alpha1.ProxyTypeMongos) {
-		return errors.New("You can use only Mongos as a proxy type for MongoDB clusters") //nolint:stylecheck
+		return errUnsupportedPSMDBProxy
 	}
 	return nil
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -391,7 +391,7 @@ func containsVersion(version string, versions []string) bool {
 
 func validateProxy(engineType, proxyType string) error {
 	if engineType == engineTypePXC {
-		if proxyType != "proxysql" || proxyType != "haproxy" {
+		if proxyType != "proxysql" && proxyType != "haproxy" {
 			return errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters")
 		}
 	}

--- a/api/validation.go
+++ b/api/validation.go
@@ -364,7 +364,7 @@ func (e *EverestServer) validateDatabaseClusterCR(ctx echo.Context, kubernetesID
 	if err := validateVersion(databaseCluster.Spec.Engine.Version, engine); err != nil {
 		return err
 	}
-	if databaseCluster.Spec.Proxy.Type != nil {
+	if databaseCluster.Spec.Proxy != nil && databaseCluster.Spec.Proxy.Type != nil {
 		if err := validateProxy(databaseCluster.Spec.Engine.Type, string(*databaseCluster.Spec.Proxy.Type)); err != nil {
 			return err
 		}
@@ -428,7 +428,7 @@ func validateBackupSpec(cluster *DatabaseCluster) error {
 
 	for _, schedule := range *cluster.Spec.Backup.Schedules {
 		if schedule.Name == "" {
-			return errors.New("'name' field cannot be empty")
+			return errors.New("'name' field for the schedules cannot be empty")
 		}
 		if schedule.Enabled && schedule.BackupStorageName == "" {
 			return errors.New("'backupStorageName' field cannot be empty when schedule is enabled")

--- a/api/validation.go
+++ b/api/validation.go
@@ -45,14 +45,18 @@ const (
 )
 
 var (
+	minStorageQuantity = resource.MustParse("1G")   //nolint:gochecknoglobals
+	minCPUQuantity     = resource.MustParse("600m") //nolint:gochecknoglobals
+	minMemQuantity     = resource.MustParse("512M") //nolint:gochecknoglobals
+
 	errDBCEmptyMetadata      = errors.New("DatabaseCluster's Metadata should not be empty")
 	errDBCNameEmpty          = errors.New("DatabaseCluster's metadata.name should not be empty")
 	errDBCNameWrongFormat    = errors.New("DatabaseCluster's metadata.name should be a string")
-	errNotEnoughMemory       = errors.New("Memory limits should be above 512M")                                                             //nolint:stylecheck
+	errNotEnoughMemory       = fmt.Errorf("Memory limits should be above %s", minMemQuantity.String())                                      //nolint:stylecheck
 	errInt64NotSupported     = errors.New("Specifying resources using int64 data type is not supported. Please use string format for that") //nolint:stylecheck
-	errNotEnoughCPU          = errors.New("CPU limits should be above 600m")                                                                //nolint:stylecheck
-	errNotEnoughDiskSize     = errors.New("Storage size should be above 1G")                                                                //nolint:stylecheck
-	errUnsupportedPXCProxy   = errors.New("You can use either HAProxy or Proxy SQL for PXC clusters")                                  //nolint:stylecheck
+	errNotEnoughCPU          = fmt.Errorf("CPU limits should be above %s", minCPUQuantity.String())                                         //nolint:stylecheck
+	errNotEnoughDiskSize     = fmt.Errorf("Storage size should be above %s", minStorageQuantity.String())                                   //nolint:stylecheck
+	errUnsupportedPXCProxy   = errors.New("You can use either HAProxy or Proxy SQL for PXC clusters")                                       //nolint:stylecheck
 	errUnsupportedPGProxy    = errors.New("You can use only PGBouncer as a proxy type for Postgres clusters")                               //nolint:stylecheck
 	errUnsupportedPSMDBProxy = errors.New("You can use only Mongos as a proxy type for MongoDB clusters")                                   //nolint:stylecheck
 	//nolint:gochecknoglobals
@@ -61,9 +65,6 @@ var (
 		everestv1alpha1.DatabaseEnginePSMDB:      psmdbDeploymentName,
 		everestv1alpha1.DatabaseEnginePostgresql: pgDeploymentName,
 	}
-	minStorageQuantity = resource.MustParse("1G")   //nolint:gochecknoglobals
-	minCPUQuantity     = resource.MustParse("600m") //nolint:gochecknoglobals
-	minMemQuantity     = resource.MustParse("512M") //nolint:gochecknoglobals
 )
 
 // ErrNameNotRFC1035Compatible when the given fieldName doesn't contain RFC 1035 compatible string.

--- a/api/validation.go
+++ b/api/validation.go
@@ -357,7 +357,7 @@ func (e *EverestServer) validateDatabaseClusterCR(ctx echo.Context, kubernetesID
 	}
 	if databaseCluster.Spec.Engine.Version != nil {
 		if len(engine.Spec.AllowedVersions) != 0 && !containsVersion(*databaseCluster.Spec.Engine.Version, engine.Spec.AllowedVersions) {
-			return fmt.Errorf("Using %s version for %s is not allowed", databaseCluster.Spec.Engine.Version, databaseCluster.Spec.Engine.Type)
+			return fmt.Errorf("Using %s version for %s is not allowed", *databaseCluster.Spec.Engine.Version, databaseCluster.Spec.Engine.Type)
 		}
 		if _, ok := engine.Status.AvailableVersions.Engine[*databaseCluster.Spec.Engine.Version]; !ok {
 			return fmt.Errorf("%s is not in available versions list", *databaseCluster.Spec.Engine.Version)
@@ -390,8 +390,10 @@ func containsVersion(version string, versions []string) bool {
 }
 
 func validateProxy(engineType, proxyType string) error {
-	if engineType == engineTypePXC && (proxyType != "proxysql" || proxyType != "haproxy") {
-		return errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters")
+	if engineType == engineTypePXC {
+		if proxyType != "proxysql" || proxyType != "haproxy" {
+			return errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters")
+		}
 	}
 
 	if engineType == engineTypePG && proxyType != "pgbouncer" {

--- a/api/validation.go
+++ b/api/validation.go
@@ -52,7 +52,7 @@ var (
 	errInt64NotSupported     = errors.New("Specifying resources using int64 data type is not supported. Please use string format for that") //nolint:stylecheck
 	errNotEnoughCPU          = errors.New("CPU limits should be above 600m")                                                                //nolint:stylecheck
 	errNotEnoughDiskSize     = errors.New("Storage size should be above 1G")                                                                //nolint:stylecheck
-	errUnsupportedPXCProxy   = errors.New("You can use only either HAProxy or Proxy SQL for PXC clusters")                                  //nolint:stylecheck
+	errUnsupportedPXCProxy   = errors.New("You can use either HAProxy or Proxy SQL for PXC clusters")                                  //nolint:stylecheck
 	errUnsupportedPGProxy    = errors.New("You can use only PGBouncer as a proxy type for Postgres clusters")                               //nolint:stylecheck
 	errUnsupportedPSMDBProxy = errors.New("You can use only Mongos as a proxy type for MongoDB clusters")                                   //nolint:stylecheck
 	//nolint:gochecknoglobals

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -303,7 +303,6 @@ func TestContainsVersion(t *testing.T) {
 			assert.Equal(t, res, tc.result)
 		})
 	}
-
 }
 
 func TestValidateVersion(t *testing.T) {
@@ -384,6 +383,7 @@ func TestValidateVersion(t *testing.T) {
 		})
 	}
 }
+
 func TestValidateBackupSpec(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -438,6 +438,7 @@ func TestValidateBackupSpec(t *testing.T) {
 		})
 	}
 }
+
 func TestValidateResourceLimits(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -17,6 +17,7 @@ package api
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -163,6 +164,101 @@ func TestValidateCreateDatabaseClusterRequest(t *testing.T) {
 				return
 			}
 			require.Equal(t, c.err.Error(), err.Error())
+		})
+	}
+}
+
+func TestValidateProxy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		engineType string
+		proxyType  string
+		err        error
+	}{
+		{
+			name:       "PXC with mongos",
+			engineType: "pxc",
+			proxyType:  "mongos",
+			err:        errUnsupportedPXCProxy,
+		},
+		{
+			name:       "PXC with pgbouncer",
+			engineType: "pxc",
+			proxyType:  "pgbouncer",
+			err:        errUnsupportedPXCProxy,
+		},
+		{
+			name:       "PXC with haproxy",
+			engineType: "pxc",
+			proxyType:  "haproxy",
+			err:        nil,
+		},
+		{
+			name:       "PXC with proxysql",
+			engineType: "pxc",
+			proxyType:  "proxysql",
+			err:        nil,
+		},
+		{
+			name:       "psmdb with mongos",
+			engineType: "psmdb",
+			proxyType:  "mongos",
+			err:        nil,
+		},
+		{
+			name:       "psmdb with pgbouncer",
+			engineType: "psmdb",
+			proxyType:  "pgbouncer",
+			err:        errUnsupportedPSMDBProxy,
+		},
+		{
+			name:       "psmdb with haproxy",
+			engineType: "psmdb",
+			proxyType:  "haproxy",
+			err:        errUnsupportedPSMDBProxy,
+		},
+		{
+			name:       "psmdb with proxysql",
+			engineType: "psmdb",
+			proxyType:  "proxysql",
+			err:        errUnsupportedPSMDBProxy,
+		},
+		{
+			name:       "postgresql with mongos",
+			engineType: "postgresql",
+			proxyType:  "mongos",
+			err:        errUnsupportedPGProxy,
+		},
+		{
+			name:       "postgresql with pgbouncer",
+			engineType: "postgresql",
+			proxyType:  "pgbouncer",
+			err:        nil,
+		},
+		{
+			name:       "postgresql with haproxy",
+			engineType: "postgresql",
+			proxyType:  "haproxy",
+			err:        errUnsupportedPGProxy,
+		},
+		{
+			name:       "postgresql with proxysql",
+			engineType: "postgresql",
+			proxyType:  "proxysql",
+			err:        errUnsupportedPGProxy,
+		},
+	}
+	for _, tc := range cases {
+		c := tc
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateProxy(c.engineType, c.proxyType)
+			if c.err == nil {
+				require.Nil(t, err)
+				return
+			}
+			assert.Equal(t, c.err.Error(), err.Error())
 		})
 	}
 }

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -303,6 +303,7 @@ func TestContainsVersion(t *testing.T) {
 			assert.Equal(t, res, tc.result)
 		})
 	}
+
 }
 
 func TestValidateVersion(t *testing.T) {
@@ -383,7 +384,6 @@ func TestValidateVersion(t *testing.T) {
 		})
 	}
 }
-
 func TestValidateBackupSpec(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -417,7 +417,7 @@ func TestValidateBackupSpec(t *testing.T) {
 			err:     errNoBackupStorageName,
 		},
 		{
-			name:    "errNoBackupStorageName",
+			name:    "valid spec",
 			cluster: []byte(`{"spec": {"backup": {"enabled": true, "schedules": [{"enabled": true, "name": "name", "backupStorageName": "some"}]}}}`),
 			err:     nil,
 		},
@@ -438,7 +438,6 @@ func TestValidateBackupSpec(t *testing.T) {
 		})
 	}
 }
-
 func TestValidateResourceLimits(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/pkg/kubernetes/client/customresources/databaseclusters.go
+++ b/pkg/kubernetes/client/customresources/databaseclusters.go
@@ -1,3 +1,4 @@
+// Package customresources ...
 // percona-everest-backend
 // Copyright (C) 2023 Percona LLC
 //
@@ -12,7 +13,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//
+//nolint:dupl
 package customresources
 
 import (

--- a/pkg/kubernetes/client/customresources/databaseengines.go
+++ b/pkg/kubernetes/client/customresources/databaseengines.go
@@ -1,0 +1,95 @@
+// percona-everest-backend
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package customresources
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	dbEnginesAPIKind = "databaseengines"
+)
+
+// DBEngines returns a db engine.
+func (c *Client) DBEngines(namespace string) DBEngineInterface { //nolint:ireturn
+	return &dbEngineClient{
+		restClient: c.restClient,
+		namespace:  namespace,
+	}
+}
+
+type dbEngineClient struct {
+	restClient rest.Interface
+	namespace  string
+}
+
+// DBEngineInterface supports list, get and watch methods.
+type DBEngineInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseEngineList, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*everestv1alpha1.DatabaseEngine, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+}
+
+// List lists database clusters based on opts.
+func (c *dbEngineClient) List(ctx context.Context, opts metav1.ListOptions) (*everestv1alpha1.DatabaseEngineList, error) {
+	result := &everestv1alpha1.DatabaseEngineList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbEnginesAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Get retrieves database cluster based on opts.
+func (c *dbEngineClient) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*everestv1alpha1.DatabaseEngine, error) {
+	result := &everestv1alpha1.DatabaseEngine{}
+	err := c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbEnginesAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Name(name).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Watch starts a watch based on opts.
+func (c *dbEngineClient) Watch( //nolint:ireturn
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
+	opts.Watch = true
+	return c.restClient.
+		Get().
+		Namespace(c.namespace).
+		Resource(dbEnginesAPIKind).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch(ctx)
+}

--- a/pkg/kubernetes/client/customresources/databaseengines.go
+++ b/pkg/kubernetes/client/customresources/databaseengines.go
@@ -1,3 +1,4 @@
+// Package customresources ...
 // percona-everest-backend
 // Copyright (C) 2023 Percona LLC
 //
@@ -12,7 +13,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//
+//nolint:dupl
 package customresources
 
 import (

--- a/pkg/kubernetes/client/database_engine.go
+++ b/pkg/kubernetes/client/database_engine.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDatabaseEngines returns list of managed database clusters.
+func (c *Client) ListDatabaseEngines(ctx context.Context) (*everestv1alpha1.DatabaseEngineList, error) {
+	return c.customClientSet.DBEngines(c.namespace).List(ctx, metav1.ListOptions{})
+}
+
+// GetDatabaseEngine returns database clusters by provided name.
+func (c *Client) GetDatabaseEngine(ctx context.Context, name string) (*everestv1alpha1.DatabaseEngine, error) {
+	return c.customClientSet.DBEngines(c.namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kubernetes/client/kubeclient_interface.go
+++ b/pkg/kubernetes/client/kubeclient_interface.go
@@ -41,6 +41,10 @@ type KubeClientConnector interface {
 	ListDatabaseClusters(ctx context.Context) (*everestv1alpha1.DatabaseClusterList, error)
 	// GetDatabaseCluster returns database clusters by provided name.
 	GetDatabaseCluster(ctx context.Context, name string) (*everestv1alpha1.DatabaseCluster, error)
+	// ListDatabaseEngines returns list of managed database clusters.
+	ListDatabaseEngines(ctx context.Context) (*everestv1alpha1.DatabaseEngineList, error)
+	// GetDatabaseEngine returns database clusters by provided name.
+	GetDatabaseEngine(ctx context.Context, name string) (*everestv1alpha1.DatabaseEngine, error)
 	// CreateMonitoringConfig creates an MonitoringConfig.
 	CreateMonitoringConfig(ctx context.Context, mc *everestv1alpha1.MonitoringConfig) error
 	// GetMonitoringConfig returns the MonitoringConfig.

--- a/pkg/kubernetes/client/mock_kube_client_connector.go
+++ b/pkg/kubernetes/client/mock_kube_client_connector.go
@@ -238,6 +238,32 @@ func (_m *MockKubeClientConnector) GetDatabaseCluster(ctx context.Context, name 
 	return r0, r1
 }
 
+// GetDatabaseEngine provides a mock function with given fields: ctx, name
+func (_m *MockKubeClientConnector) GetDatabaseEngine(ctx context.Context, name string) (*v1alpha1.DatabaseEngine, error) {
+	ret := _m.Called(ctx, name)
+
+	var r0 *v1alpha1.DatabaseEngine
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1alpha1.DatabaseEngine, error)); ok {
+		return rf(ctx, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *v1alpha1.DatabaseEngine); ok {
+		r0 = rf(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseEngine)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetMonitoringConfig provides a mock function with given fields: ctx, name
 func (_m *MockKubeClientConnector) GetMonitoringConfig(ctx context.Context, name string) (*v1alpha1.MonitoringConfig, error) {
 	ret := _m.Called(ctx, name)
@@ -488,6 +514,32 @@ func (_m *MockKubeClientConnector) ListDatabaseClusters(ctx context.Context) (*v
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1alpha1.DatabaseClusterList)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDatabaseEngines provides a mock function with given fields: ctx
+func (_m *MockKubeClientConnector) ListDatabaseEngines(ctx context.Context) (*v1alpha1.DatabaseEngineList, error) {
+	ret := _m.Called(ctx)
+
+	var r0 *v1alpha1.DatabaseEngineList
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*v1alpha1.DatabaseEngineList, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *v1alpha1.DatabaseEngineList); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.DatabaseEngineList)
 		}
 	}
 

--- a/pkg/kubernetes/database_engine.go
+++ b/pkg/kubernetes/database_engine.go
@@ -13,7 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+// Package kubernetes ...
+package kubernetes
 
-//go:generate ../../../bin/ifacemaker -f backup_storage.go -f client.go -f database_cluster.go -f database_engine.go -f monitoring_config.go -f namespace.go -f node.go -f pod.go -f resource.go -f secret.go -f storage.go -s Client -i KubeClientConnector -p client -o kubeclient_interface.go
-//go:generate ../../../bin/mockery --name=KubeClientConnector --case=snake --inpackage
+import (
+	"context"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+)
+
+// ListDatabaseEngines returns list of managed database clusters.
+func (k *Kubernetes) ListDatabaseEngines(ctx context.Context) (*everestv1alpha1.DatabaseEngineList, error) {
+	return k.client.ListDatabaseEngines(ctx)
+}
+
+// GetDatabaseEngine returns database clusters by provided name.
+func (k *Kubernetes) GetDatabaseEngine(ctx context.Context, name string) (*everestv1alpha1.DatabaseEngine, error) {
+	return k.client.GetDatabaseEngine(ctx, name)
+}


### PR DESCRIPTION
[![EVEREST-256](https://badgen.net/badge/JIRA/EVEREST-256/green)](https://jira.percona.com/browse/EVEREST-256) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-256 Requires validation improvements for a database cluster CR before proxying and storing in etcd.

*Short explanation of the problem.*

**Related pull requests**

- https://github.com/percona/everest-operator/pull/50

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*
I had different options to enable validation.

1. Using [https://kubernetes.io/blog/2022/09/23/crd-validation-rules-beta/.](https://kubernetes.io/blog/2022/09/23/crd-validation-rules-beta/) but this can be implemented once the lowest level of supported k8s clusters will be 1.25 and according to https://endoflife.date/amazon-eks EOL for 1.24 EKS will be 2024-01-31. Hence, some validations can move to the operator side using validation rules in Q1-Q2 2024
2. Another option is to have admission webhooks https://cloud.redhat.com/blog/dynamic-admission-control but after a long discussion with Chetan, Slava and others right now it's not a good time for that feature on the operator side and it requires the operator to run cluster-wide with the limitation across specified namespaces.

Hence, some validation rules (basic ones) are implemented on the operator side and some advanced rules are implemented on the BE side. 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?