### PR TITLE
EVEREST-444 Add configurable bind address for the everest container

### DIFF
--- a/deploy/quickstart-compose.yml
+++ b/deploy/quickstart-compose.yml
@@ -18,4 +18,4 @@ services:
     environment:
       - DSN=postgres://admin:pwd@pg:5432/postgres?sslmode=disable
     ports:
-      - 8080:8080
+      - ${EVEREST_BIND_ADDR:-127.0.0.1}:8080:8080

--- a/deploy/quickstart-compose.yml
+++ b/deploy/quickstart-compose.yml
@@ -18,4 +18,4 @@ services:
     environment:
       - DSN=postgres://admin:pwd@pg:5432/postgres?sslmode=disable
     ports:
-      - 127.0.0.1:8080:8080
+      - 8080:8080


### PR DESCRIPTION
[![EVEREST-444](https://badgen.net/badge/JIRA/EVEREST-444/green)](https://jira.percona.com/browse/EVEREST-444) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem:**
In [EVEREST-333](https://jira.percona.com/browse/EVEREST-333) (#142) we identified and fixed a security vulnerability where we were exposing everest's port to 0.0.0.0 by default.
However, this fix broke the ability for users to access everest from outside localhost which is must have.

**Related pull requests**

- #142

**Cause:**
#142 

**Solution:**
Add a `EVEREST_BIND_ADDR` env var which is `127.0.0.1` by default but allows for users to control the bind address and thus the exposure of the everest container.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~