### PR TITLE
EVEREST-428

### DIFF
--- a/.github/workflows/rc_rebuild.yml
+++ b/.github/workflows/rc_rebuild.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - release-[0-9]+.[0-9]+.[0-9]+*
+  workflow_run:
+    workflows: ["Create RC branches"]
+    types:
+      - completed
 
 jobs:
   build:


### PR DESCRIPTION
[![EVEREST-428](https://badgen.net/badge/JIRA/EVEREST-428/green)](https://jira.percona.com/browse/EVEREST-428) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**UPDATE RC CI**
---
**Problem:**
EVEREST-428

*The `rc_rebuild` workflow wasn't triggered after the  `rc_create` even though there was a push to the existing release branch. However the manual commit to that branch triggers the workflow just fine*

**Cause:**
*Workflows can not trigger other workflows by design to prevent endless loops*

**Solution:**
*Configure the workflow run explicitly*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?