### PR TITLE
EVEREST-429 release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,31 +3,27 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: The release version in v*.*.* format
+      tag:
+        description: The release tag in v*.*.* format
         required: true
-  push:
-    branches:
-      - EVEREST-429-release-pipeline
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      # VERSION: ${{ github.event.inputs.version }}
-      VERSION: v0.3.0
+      TAG: ${{ github.event.inputs.tag }}
       RC_BRANCH: '' # the release branch is based on the RC branch
     steps:
       - name: Validate input
         run: |
           echo $RC_BRANCH
-          if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Wrong version format provided, please use v*.*.* format" 
+          if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Wrong tag format provided, please use v*.*.* format" 
             exit 1
           fi
       - name: Define release branch name in the format "release-*.*.*"
         run: |
-          echo "RC_BRANCH=release-${VERSION#v}" >> $GITHUB_ENV
+          echo "RC_BRANCH=release-${TAG#v}" >> $GITHUB_ENV
 
       - name: Configure git for private modules
         env:
@@ -50,29 +46,29 @@ jobs:
       - name: Everest CLI - create tag
         run: |
           cd percona-everest-cli
-          git tag $VERSION
+          git tag $TAG
           
           # update branch names in the install.sh script:
           # e.g. replace release-0.3.0 with v0.3.0
-          sed -i "s/$RC_BRANCH/$VERSION/g" install.sh
+          sed -i "s/$RC_BRANCH/$TAG/g" install.sh
           echo "$(git diff install.sh)"
-          git commit -a -m "update version tag"
+          git commit -a -m "update scripts"
           
-          #git push origin $VERSION
+          git push origin $TAG
 
       - name:  Everest CLI - build binaries
         run: |
           cd percona-everest-cli
           make release
 
-      # !!! conflict with cli push to tags
-#      - name: Everest CLI - create release with binaries
-#        uses: softprops/action-gh-release@v1
-#        with:
-#          files: |
-#            dist/*
-#        env:
-#          GITHUB_TOKEN: ${{ github.token }}
+      - name: Everest CLI - create release with binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.TAG }}
+          files: |
+            dist/*
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Everest Catalog - check out
         uses: actions/checkout@v4
@@ -85,8 +81,8 @@ jobs:
       - name: Everest Catalog - create tag
         run: |
           cd everest-catalog
-          git tag $VERSION
-         # git push origin $VERSION
+          git tag $TAG
+          git push origin $TAG
       
 
       - name: Everest Frontend - check out
@@ -100,36 +96,36 @@ jobs:
       - name: Everest Frontend - create tag
         run: |
           cd percona-everest-frontend
-          git tag $VERSION  
-         # git push origin $VERSION
+          git tag $TAG  
+          git push origin $TAG
           
-#      - name: Everest Frontend - run with Node 16
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: ${{ matrix.node-version }}
-#
-#      - name: Everest Frontend - install Bit Version Manager
-#        run: npm i -g @teambit/bvm
-#
-#      - name: Everest Frontend - install latest Bit version
-#        run: bvm install 0.2.3
-#
-#      - name: Everest Frontend - add bvm bin folder to path
-#        run: echo "$HOME/bin" >> $GITHUB_PATH
-#
-#      - name: Everest Frontend - set up bit config
-#        env:
-#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-#        run: bit config set user.token $BIT_TOKEN
-#
-#      - name: Everest Frontend - build app
-#        run: |
-#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-#          bit install --recurring-install
-#          bit snap
-#          bit artifacts percona.apps/everest --out-dir build
-#          mkdir ${GITHUB_WORKSPACE}/front
-#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+      - name: Everest Frontend - run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Everest Frontend - install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Everest Frontend - install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Everest Frontend - add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Everest Frontend - set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Everest Frontend - build app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
 
       - name: Everest Backend - check out
@@ -142,37 +138,37 @@ jobs:
         run: |
           cd backend
           # Check if the branch already exists
-          git tag $VERSION  
+          git tag $TAG 
           
           # update image names in scripts. since the branch is created based on the RC-branch,
           # the perconalab/everest:vX.Y.Z image reference is already present in the scripts
           sed -i "s/perconalab\/everest/percona\/percona-everest/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
           echo "$(git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml)"
-          git commit -a -m "update version tag"
+          git commit -a -m "update scripts"
           
-          # git push origin $VERSION
+          git push origin $TAG
 
-#      - name: Everest Backend - Embed Everest Frontend app into backend
-#        run: |
-#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-#          cd ${GITHUB_WORKSPACE}/backend
+      - name: Everest Backend - Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
 
       - name: Everest - Setup docker build metadata
         uses: docker/metadata-action@v5
         id: meta
         with:
           images: percona/percona-everest
-          tags: ${{ env.VERSION }}
+          tags: ${{ env.TAG }}
 
-#      - name: Everest - Login to GitHub Container Registry
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Everest - Build and Push everest release image
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: backend
-#          push: true
-#          tags: ${{ steps.meta.outputs.tags }}
+      - name: Everest - Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Everest - Build and Push everest release image
+        uses: docker/build-push-action@v5
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
           #git push origin $VERSION
 
       - name:  Everest CLI - build binaries
-        run: make release
+        run: |
+          cat Makefile
+          make release
 
       # !!! conflict with cli push to tags
 #      - name: Everest CLI - create release with binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,10 +152,10 @@ jobs:
           
           # git push origin $VERSION
 
-      - name: Everest Backend - Embed Everest Frontend app into backend
-        run: |
-          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
-          cd ${GITHUB_WORKSPACE}/backend
+#      - name: Everest Backend - Embed Everest Frontend app into backend
+#        run: |
+#          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+#          cd ${GITHUB_WORKSPACE}/backend
 
       - name: Everest - Setup docker build metadata
         uses: docker/metadata-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name:  Everest CLI - build binaries
         run: |
-          echo $(ls)
+          cd percona-everest-cli
           make release
 
       # !!! conflict with cli push to tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,16 @@ on:
       version:
         description: The release version in v*.*.* format
         required: true
+  push:
+    branches:
+      - EVEREST-429-release-pipeline
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      VERSION: ${{ github.event.inputs.version }}
+      # VERSION: ${{ github.event.inputs.version }}
+      VERSION: v0.3.0
       RC_BRANCH: ''
     steps:
       - name: Validate input
@@ -48,26 +52,25 @@ jobs:
           cd percona-everest-cli
           git tag $VERSION
           
-          # update image names in scripts. since the branch is created based on the RC-branch,
-          # the perconalab/everest:vX.Y.Z image reference is already present in the scripts
-          sed -i "s/perconalab\/everest/percona\/percona-everest/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
-          echo "$(git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml)"
+          # update branch names in the install.sh script:
+          # e.g. replace release-0.3.0 with v0.3.0
+          sed -i "s/$RC_BRANCH/$VERSION/g" install.sh
+          echo "$(git diff install.sh)"
+          git commit -a -m "update version tag"
           
-          # !!! update scripts - tag & registry name
-          
-          git push origin $VERSION
+          #git push origin $VERSION
 
       - name:  Everest CLI - build binaries
         run: make release
 
       # !!! conflict with cli push to tags
-      - name: Everest CLI - create release with binaries
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            dist/*
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+#      - name: Everest CLI - create release with binaries
+#        uses: softprops/action-gh-release@v1
+#        with:
+#          files: |
+#            dist/*
+#        env:
+#          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Everest catalog - check out
         uses: actions/checkout@v4
@@ -81,7 +84,7 @@ jobs:
         run: |
           cd everest-catalog
           git tag $VERSION
-          git push origin $VERSION
+         # git push origin $VERSION
       
 
       - name: Everest frontend - check out
@@ -96,35 +99,35 @@ jobs:
         run: |
           cd percona-everest-frontend
           git tag $VERSION  
-          git push origin $VERSION
+         # git push origin $VERSION
           
-      - name: Everest Frontend - run with Node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Everest Frontend - install Bit Version Manager
-        run: npm i -g @teambit/bvm
-
-      - name: Everest Frontend - install latest Bit version
-        run: bvm install 0.2.3
-
-      - name: Everest Frontend - add bvm bin folder to path
-        run: echo "$HOME/bin" >> $GITHUB_PATH
-
-      - name: Everest Frontend - set up bit config
-        env:
-          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
-        run: bit config set user.token $BIT_TOKEN
-
-      - name: Everest Frontend - build app
-        run: |
-          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-          bit install --recurring-install
-          bit snap
-          bit artifacts percona.apps/everest --out-dir build
-          mkdir ${GITHUB_WORKSPACE}/front
-          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+#      - name: Everest Frontend - run with Node 16
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#
+#      - name: Everest Frontend - install Bit Version Manager
+#        run: npm i -g @teambit/bvm
+#
+#      - name: Everest Frontend - install latest Bit version
+#        run: bvm install 0.2.3
+#
+#      - name: Everest Frontend - add bvm bin folder to path
+#        run: echo "$HOME/bin" >> $GITHUB_PATH
+#
+#      - name: Everest Frontend - set up bit config
+#        env:
+#          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+#        run: bit config set user.token $BIT_TOKEN
+#
+#      - name: Everest Frontend - build app
+#        run: |
+#          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+#          bit install --recurring-install
+#          bit snap
+#          bit artifacts percona.apps/everest --out-dir build
+#          mkdir ${GITHUB_WORKSPACE}/front
+#          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
 
       - name: Everest Backend - check out
@@ -143,8 +146,9 @@ jobs:
           # the perconalab/everest:vX.Y.Z image reference is already present in the scripts
           sed -i "s/perconalab\/everest/percona\/percona-everest/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
           echo "$(git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml)"
+          git commit -a -m "update version tag"
           
-          git push origin $VERSION
+          # git push origin $VERSION
 
       - name: Everest Backend - Embed Everest Frontend app into backend
         run: |
@@ -158,15 +162,15 @@ jobs:
           images: percona/percona-everest
           tags: ${{ env.VERSION }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and Push everest RC-image
-        uses: docker/build-push-action@v5
-        with:
-          context: backend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+#      - name: Login to GitHub Container Registry
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and Push everest RC-image
+#        uses: docker/build-push-action@v5
+#        with:
+#          context: backend
+#          push: true
+#          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       # VERSION: ${{ github.event.inputs.version }}
       VERSION: v0.3.0
-      RC_BRANCH: ''
+      RC_BRANCH: '' # the release branch is based on the RC branch
     steps:
       - name: Validate input
         run: |
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: percona/percona-everest-cli
-          ref: ${{ env.RELEASE_BRANCH_NAME }}
+          ref: ${{ env.RC_BRANCH }}
           path: percona-everest-cli
           token: ${{ secrets.ROBOT_TOKEN }}
 
@@ -72,26 +72,26 @@ jobs:
 #        env:
 #          GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Everest catalog - check out
+      - name: Everest Catalog - check out
         uses: actions/checkout@v4
         with:
           repository: percona/everest-catalog
-          ref: ${{ env.RELEASE_BRANCH_NAME }}
+          ref: ${{ env.RC_BRANCH }}
           path: everest-catalog
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Everest catalog - create tag
+      - name: Everest Catalog - create tag
         run: |
           cd everest-catalog
           git tag $VERSION
          # git push origin $VERSION
       
 
-      - name: Everest frontend - check out
+      - name: Everest Frontend - check out
         uses: actions/checkout@v4
         with:
           repository: percona/percona-everest-frontend
-          ref: ${{ env.RELEASE_BRANCH_NAME }}
+          ref: ${{ env.RC_BRANCH }}
           path: percona-everest-frontend
           token: ${{ secrets.ROBOT_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./backend
-          ref: ${{ env.RELEASE_BRANCH_NAME }}
+          ref: ${{ env.RC_BRANCH }}
 
       - name: Everest Backend - create tag
         run: |
@@ -162,13 +162,13 @@ jobs:
           images: percona/percona-everest
           tags: ${{ env.VERSION }}
 
-#      - name: Login to GitHub Container Registry
+#      - name: Everest - Login to GitHub Container Registry
 #        uses: docker/login-action@v3
 #        with:
 #          username: ${{ secrets.DOCKERHUB_USERNAME }}
 #          password: ${{ secrets.DOCKERHUB_TOKEN }}
 #
-#      - name: Build and Push everest RC-image
+#      - name: Everest - Build and Push everest release image
 #        uses: docker/build-push-action@v5
 #        with:
 #          context: backend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,26 @@ jobs:
           cd percona-everest-cli
           git tag $VERSION
           
+          # update image names in scripts. since the branch is created based on the RC-branch,
+          # the perconalab/everest:vX.Y.Z image reference is already present in the scripts
+          sed -i "s/perconalab\/everest/percona\/percona-everest/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+          echo "$(git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml)"
+          
           # !!! update scripts - tag & registry name
           
           git push origin $VERSION
 
-      - name: Everest CLI - create release
-        run: |
-          # !!!! create release without pre-release tag
+      - name:  Everest CLI - build binaries
+        run: make release
+
+      # !!! conflict with cli push to tags
+      - name: Everest CLI - create release with binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Everest catalog - check out
         uses: actions/checkout@v4
@@ -68,9 +81,6 @@ jobs:
         run: |
           cd everest-catalog
           git tag $VERSION
-
-          # !!! update smth?
-
           git push origin $VERSION
       
 
@@ -88,7 +98,7 @@ jobs:
           git tag $VERSION  
           git push origin $VERSION
           
-            - name: Run with Node 16
+      - name: Everest Frontend - run with Node 16
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
@@ -129,8 +139,10 @@ jobs:
           # Check if the branch already exists
           git tag $VERSION  
           
-          # !!! update tag refs in scripts
-          sed -i "s/dev-latest/$VERSION/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+          # update image names in scripts. since the branch is created based on the RC-branch,
+          # the perconalab/everest:vX.Y.Z image reference is already present in the scripts
+          sed -i "s/perconalab\/everest/percona\/percona-everest/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+          echo "$(git diff deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml)"
           
           git push origin $VERSION
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Create RC branches
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The release version in v*.*.* format
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      RC_BRANCH: ''
+    steps:
+      - name: Validate input
+        run: |
+          echo $RC_BRANCH
+          if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Wrong version format provided, please use v*.*.* format" 
+            exit 1
+          fi
+      - name: Define release branch name in the format "release-*.*.*"
+        run: |
+          echo "RC_BRANCH=release-${VERSION#v}" >> $GITHUB_ENV
+
+      - name: Configure git for private modules
+        env:
+          ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
+        run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
+
+      - name: Check out Everest CLI
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-cli
+          ref: 'main'
+          path: percona-everest-cli
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Create Everest CLI RC-branch
+        run: |
+          cd percona-everest-cli
+          # Check if the branch already exists
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          
+          if [[ -z ${check_branch} ]]; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH   
+          fi
+          
+
+      - name: Check out Everest catalog
+        uses: actions/checkout@v4
+        with:
+          repository: percona/everest-catalog
+          ref: 'main'
+          path: everest-catalog
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Create Everest catalog RC-branch
+        run: |
+          cd everest-catalog
+          # Check if the branch already exists
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          
+          if [[ -z ${check_branch} ]]; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH    
+          fi
+
+
+      - name: Check out Everest frontend
+        uses: actions/checkout@v4
+        with:
+          repository: percona/percona-everest-frontend
+          ref: 'main'
+          path: percona-everest-frontend
+          token: ${{ secrets.ROBOT_TOKEN }}
+
+      - name: Create Everest Frontend RC-branch
+        run: |
+          cd percona-everest-frontend
+
+          # Check if the branch already exists
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          
+          if [[ -z ${check_branch} ]]; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH   
+          fi
+
+      - name: Check out Everest Backend
+        uses: actions/checkout@v4
+        with:
+          path: ./backend
+          ref: 'main'
+
+      - name: Create and update Everest Backend RC-branch
+        run: |
+          cd backend
+          # Check if the branch already exists
+          git fetch
+          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          
+          if [[ -z ${check_branch} ]]; then
+            git checkout -b $RC_BRANCH
+            git push origin $RC_BRANCH  
+            
+            # update tag refs in scripts
+            sed -i "s/dev-latest/$VERSION/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+            
+            # configure userdata for commits
+            git config --global user.email "everest-ci@percona.com"
+            git config --global user.name "Everest RC CI triggered by ${{ github.actor }}"
+            
+            # commit and push the updated files
+            git commit -a -m "update version tag"
+            git push origin $RC_BRANCH  
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name:  Everest CLI - build binaries
         run: |
-          cat Makefile
+          echo $(ls)
           make release
 
       # !!! conflict with cli push to tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create RC branches
+name: Release
 
 on:
   workflow_dispatch:
@@ -30,94 +30,131 @@ jobs:
           ROBOT_TOKEN: ${{ secrets.ROBOT_TOKEN }}
         run: git config --global url."https://percona-platform-robot:${ROBOT_TOKEN}@github.com".insteadOf "https://github.com"
 
-      - name: Check out Everest CLI
+      - name: Configure git userdata for commits
+        run: | 
+          git config --global user.email "everest-ci@percona.com"
+          git config --global user.name "Everest RC CI triggered by ${{ github.actor }}"
+
+      - name: Everest CLI - check out
         uses: actions/checkout@v4
         with:
           repository: percona/percona-everest-cli
-          ref: 'main'
+          ref: ${{ env.RELEASE_BRANCH_NAME }}
           path: percona-everest-cli
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Create Everest CLI RC-branch
+      - name: Everest CLI - create tag
         run: |
           cd percona-everest-cli
-          # Check if the branch already exists
-          git fetch
-          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          git tag $VERSION
           
-          if [[ -z ${check_branch} ]]; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH   
-          fi
+          # !!! update scripts - tag & registry name
           
+          git push origin $VERSION
 
-      - name: Check out Everest catalog
+      - name: Everest CLI - create release
+        run: |
+          # !!!! create release without pre-release tag
+
+      - name: Everest catalog - check out
         uses: actions/checkout@v4
         with:
           repository: percona/everest-catalog
-          ref: 'main'
+          ref: ${{ env.RELEASE_BRANCH_NAME }}
           path: everest-catalog
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Create Everest catalog RC-branch
+      - name: Everest catalog - create tag
         run: |
           cd everest-catalog
-          # Check if the branch already exists
-          git fetch
-          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
-          
-          if [[ -z ${check_branch} ]]; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH    
-          fi
+          git tag $VERSION
 
+          # !!! update smth?
 
-      - name: Check out Everest frontend
+          git push origin $VERSION
+      
+
+      - name: Everest frontend - check out
         uses: actions/checkout@v4
         with:
           repository: percona/percona-everest-frontend
-          ref: 'main'
+          ref: ${{ env.RELEASE_BRANCH_NAME }}
           path: percona-everest-frontend
           token: ${{ secrets.ROBOT_TOKEN }}
 
-      - name: Create Everest Frontend RC-branch
+      - name: Everest Frontend - create tag
         run: |
           cd percona-everest-frontend
-
-          # Check if the branch already exists
-          git fetch
-          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          git tag $VERSION  
+          git push origin $VERSION
           
-          if [[ -z ${check_branch} ]]; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH   
-          fi
+            - name: Run with Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
-      - name: Check out Everest Backend
+      - name: Everest Frontend - install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Everest Frontend - install latest Bit version
+        run: bvm install 0.2.3
+
+      - name: Everest Frontend - add bvm bin folder to path
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Everest Frontend - set up bit config
+        env:
+          BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+        run: bit config set user.token $BIT_TOKEN
+
+      - name: Everest Frontend - build app
+        run: |
+          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
+          bit install --recurring-install
+          bit snap
+          bit artifacts percona.apps/everest --out-dir build
+          mkdir ${GITHUB_WORKSPACE}/front
+          cp -rf build/percona.apps_everest/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+
+
+      - name: Everest Backend - check out
         uses: actions/checkout@v4
         with:
           path: ./backend
-          ref: 'main'
+          ref: ${{ env.RELEASE_BRANCH_NAME }}
 
-      - name: Create and update Everest Backend RC-branch
+      - name: Everest Backend - create tag
         run: |
           cd backend
           # Check if the branch already exists
-          git fetch
-          check_branch=$(git ls-remote --heads origin ${RC_BRANCH})
+          git tag $VERSION  
           
-          if [[ -z ${check_branch} ]]; then
-            git checkout -b $RC_BRANCH
-            git push origin $RC_BRANCH  
-            
-            # update tag refs in scripts
-            sed -i "s/dev-latest/$VERSION/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
-            
-            # configure userdata for commits
-            git config --global user.email "everest-ci@percona.com"
-            git config --global user.name "Everest RC CI triggered by ${{ github.actor }}"
-            
-            # commit and push the updated files
-            git commit -a -m "update version tag"
-            git push origin $RC_BRANCH  
-          fi
+          # !!! update tag refs in scripts
+          sed -i "s/dev-latest/$VERSION/g" deploy/quickstart-compose.yml deploy/quickstart-k8s.yaml
+          
+          git push origin $VERSION
+
+      - name: Everest Backend - Embed Everest Frontend app into backend
+        run: |
+          cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
+          cd ${GITHUB_WORKSPACE}/backend
+
+      - name: Everest - Setup docker build metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: percona/percona-everest
+          tags: ${{ env.VERSION }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push everest RC-image
+        uses: docker/build-push-action@v5
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
**Release pipeline**
---
**Problem:**
EVEREST-429

Release pipeline creates tags in the `percona-everest-frontend`, `percona-everest-backend`, `everest-catalog` repos. 
For the cli repo it publishes the release with the existing tag that was created by the `rc-create.yaml`.
 

**Related pull requests**

- https://github.com/percona/percona-everest-cli/pull/153
