### PR TITLE
EVEREST-301 Shorten the error message for backup storage creation

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -267,11 +267,11 @@ func validateCreateBackupStorageRequest(ctx echo.Context, l *zap.SugaredLogger) 
 	// check data access
 	if err := validateStorageAccessByCreate(params, l); err != nil {
 		if errors.Is(err, errUserFacingMsg) {
-			return nil, errors.Join(err, errors.New("could not connect to the backup storage, please check the new credentials are correct"))
+			return nil, errors.Join(err, errors.New("please check credentials"))
 		}
 
 		l.Error(err)
-		return nil, errors.New("could not connect to the backup storage, please check the new credentials are correct")
+		return nil, errors.New("please check credentials")
 	}
 
 	return &params, nil


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-301

*Short explanation of the problem.*
On the UI error messages for backup storage cuts and the end user do not see that message

**Solution:**
*Short explanation of the solution we are providing with this PR.*

Shorten error messages 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
