### PR TITLE
EVEREST-468 Restrict scaling down to single node cluster

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -159,6 +159,12 @@ func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID str
 		}
 	}
 	if *dbc.Spec.Engine.Replicas < oldDB.Spec.Engine.Replicas && *dbc.Spec.Engine.Replicas == 1 {
+		// XXX: We can scale down multiple node clusters to a single node but we need to set
+		// `allowUnsafeConfigurations` to `true`. Having this configuration is not recommended
+		// and makes a database cluster unsafe. Once allowUnsafeConfigurations set to true you
+		// can't set it to false for all operators and psmdb operator does not support it.
+		//
+		// Once it is supported by all operators we can revert this.
 		return ctx.JSON(http.StatusBadRequest, Error{
 			Message: pointer.ToString(fmt.Sprintf("Can not scale down %d node cluster to 1. The operation is not supported", oldDB.Spec.Engine.Replicas)),
 		})

--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -158,6 +158,11 @@ func (e *EverestServer) UpdateDatabaseCluster(ctx echo.Context, kubernetesID str
 			})
 		}
 	}
+	if *dbc.Spec.Engine.Replicas < oldDB.Spec.Engine.Replicas && *dbc.Spec.Engine.Replicas == 1 {
+		return ctx.JSON(http.StatusBadRequest, Error{
+			Message: pointer.ToString(fmt.Sprintf("Can not scale down %d node cluster to 1. The operation is not supported", oldDB.Spec.Engine.Replicas)),
+		})
+	}
 
 	newMonitoringName := monitoringNameFrom(dbc)
 	newBackupNames := backupStorageNamesFrom(dbc)

--- a/api/validation.go
+++ b/api/validation.go
@@ -573,7 +573,7 @@ func validateDatabaseClusterOnUpdate(dbc *DatabaseCluster, oldDB *everestv1alpha
 		// can't set it to false for all operators and psmdb operator does not support it.
 		//
 		// Once it is supported by all operators we can revert this.
-		return fmt.Errorf("can not scale down %d node cluster to 1. The operation is not supported", oldDB.Spec.Engine.Replicas)
+		return fmt.Errorf("cannot scale down %d node cluster to 1. The operation is not supported", oldDB.Spec.Engine.Replicas)
 	}
 	return nil
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -556,3 +556,24 @@ func validateStorageSize(cluster *DatabaseCluster) error {
 	}
 	return nil
 }
+
+func validateDatabaseClusterOnUpdate(dbc *DatabaseCluster, oldDB *everestv1alpha1.DatabaseCluster) error {
+	if dbc.Spec.Engine.Version != nil {
+		// XXX: Right now we do not support upgrading of versions
+		// because it varies across different engines. Also, we should
+		// prohibit downgrades. Hence, if versions are not equal we just return an error
+		if oldDB.Spec.Engine.Version != *dbc.Spec.Engine.Version {
+			return errors.New("changing version is not allowed")
+		}
+	}
+	if *dbc.Spec.Engine.Replicas < oldDB.Spec.Engine.Replicas && *dbc.Spec.Engine.Replicas == 1 {
+		// XXX: We can scale down multiple node clusters to a single node but we need to set
+		// `allowUnsafeConfigurations` to `true`. Having this configuration is not recommended
+		// and makes a database cluster unsafe. Once allowUnsafeConfigurations set to true you
+		// can't set it to false for all operators and psmdb operator does not support it.
+		//
+		// Once it is supported by all operators we can revert this.
+		return fmt.Errorf("can not scale down %d node cluster to 1. The operation is not supported", oldDB.Spec.Engine.Replicas)
+	}
+	return nil
+}


### PR DESCRIPTION
[![EVEREST-468](https://badgen.net/badge/JIRA/EVEREST-468/green)](https://jira.percona.com/browse/EVEREST-468) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-468

*Short explanation of the problem.*
We can scale down multiple node clusters to a single node but we need to set `allowUnsafeConfigurations` to `true`. Having this configuration is not recommended and makes a database cluster unsafe. Once allowUnsafeConfigurations set to true you can't set it to false for all operators and psmdb operator does not support it. Once it is supported by all operators we can revert this.


**Solution:**
*Short explanation of the solution we are providing with this PR.*

Restrict scaling to 1 for multiple node clusters 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?