### PR TITLE
EVEREST-506 Prod telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,3 +122,4 @@ jobs:
           context: backend
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: "IS_RELEASE=1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,4 +122,5 @@ jobs:
           context: backend
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          build-args: "IS_RELEASE=1"
+          build-args: |
+            "IS_RELEASE=1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,13 @@ WORKDIR /everest
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /everest-api cmd/main.go
+ARG TELEMETRY_URL="https://check.percona.com"
+ARG TELEMETRY_INTERVAL="24h"
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags " \
+    -X 'github.com/percona/percona-everest-backend/cmd/config.TelemetryURL=$TELEMETRY_URL'  \
+    -X 'github.com/percona/percona-everest-backend/cmd/config.TelemetryInterval=$TELEMETRY_INTERVAL'" \
+    -o /everest-api cmd/main.go
 RUN apk add -U --no-cache ca-certificates
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,22 @@ WORKDIR /everest
 
 COPY . .
 
+ARG IS_RELEASE
+
 ARG TELEMETRY_URL="https://check.percona.com"
 ARG TELEMETRY_INTERVAL="24h"
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags " \
-    -X 'github.com/percona/percona-everest-backend/cmd/config.TelemetryURL=$TELEMETRY_URL'  \
-    -X 'github.com/percona/percona-everest-backend/cmd/config.TelemetryInterval=$TELEMETRY_INTERVAL'" \
-    -o /everest-api cmd/main.go
+RUN if [[ $IS_RELEASE = 1 ]]; then  \
+    # for the release builds set up the production telemetry parameters
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "\
+            -X 'github.com/percona/percona-everest-backend/cmd/config.TelemetryURL=$TELEMETRY_URL'  \
+            -X 'github.com/percona/percona-everest-backend/cmd/config.TelemetryInterval=$TELEMETRY_INTERVAL'"  \
+        -o /everest-api cmd/main.go; \
+    else \
+     # for all the other builds no telemetry parameters are provided by default
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /everest-api cmd/main.go; \
+fi
+
 RUN apk add -U --no-cache ca-certificates
 
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,9 @@ test-crosscover:        ## Run tests and collect cross-package coverage informat
 run: build            ## Run binary
 	bin/percona-everest-backend
 
-run-debug: build-debug            ## Run binary
+run-debug: build-debug    ## Run binary
+	TELEMETRY_URL=https://check-dev.percona.com \
+	TELEMETRY_INTERVAL=30m \
 	bin/percona-everest-backend-debug
 
 local-env-up:                 ## Start development environment

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -18,20 +18,36 @@ package config
 
 import "github.com/kelseyhightower/envconfig"
 
+var (
+	// TelemetryURL Everest telemetry endpoint. The variable is set for the release builds via ldflags
+	// to have the correct default telemetry url
+	TelemetryURL string = ""
+	// TelemetryInterval Everest telemetry sending frequency. The variable is set for the release builds via ldflags
+	// to have the correct default telemetry interval
+	TelemetryInterval string = ""
+)
+
 // EverestConfig stores the configuration for the application.
 type EverestConfig struct {
 	DSN      string `default:"postgres://admin:pwd@127.0.0.1:5432/postgres?sslmode=disable" envconfig:"DSN"`
 	HTTPPort int    `default:"8080" envconfig:"HTTP_PORT"`
 	Verbose  bool   `default:"false" envconfig:"VERBOSE"`
 	// TelemetryURL Everest telemetry endpoint.
-	TelemetryURL string `default:"https://check.percona.com" envconfig:"TELEMETRY_URL"`
+	TelemetryURL string `envconfig:"TELEMETRY_URL"`
 	// TelemetryInterval Everest telemetry sending frequency.
-	TelemetryInterval string `default:"24h" envconfig:"TELEMETRY_INTERVAL"`
+	TelemetryInterval string `envconfig:"TELEMETRY_INTERVAL"`
 }
 
 // ParseConfig parses env vars and fills EverestConfig.
 func ParseConfig() (*EverestConfig, error) {
 	c := &EverestConfig{}
 	err := envconfig.Process("", c)
+	if c.TelemetryURL == "" {
+		c.TelemetryURL = TelemetryURL
+	}
+	if c.TelemetryInterval == "" {
+		c.TelemetryInterval = TelemetryInterval
+	}
+
 	return c, err
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -18,13 +18,14 @@ package config
 
 import "github.com/kelseyhightower/envconfig"
 
+//nolint:gochecknoglobals
 var (
 	// TelemetryURL Everest telemetry endpoint. The variable is set for the release builds via ldflags
-	// to have the correct default telemetry url
-	TelemetryURL string = ""
+	// to have the correct default telemetry url.
+	TelemetryURL string
 	// TelemetryInterval Everest telemetry sending frequency. The variable is set for the release builds via ldflags
-	// to have the correct default telemetry interval
-	TelemetryInterval string = ""
+	// to have the correct default telemetry interval.
+	TelemetryInterval string
 )
 
 // EverestConfig stores the configuration for the application.

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -16,7 +16,10 @@
 // Package config ...
 package config
 
-import "github.com/kelseyhightower/envconfig"
+import (
+	"github.com/kelseyhightower/envconfig"
+	"os"
+)
 
 //nolint:gochecknoglobals
 var (
@@ -44,7 +47,10 @@ func ParseConfig() (*EverestConfig, error) {
 	c := &EverestConfig{}
 	err := envconfig.Process("", c)
 	if c.TelemetryURL == "" {
-		c.TelemetryURL = TelemetryURL
+		// checking opt-out - if the env variable does not even exist, set the default URL
+		if _, ok := os.LookupEnv("TELEMETRY_URL"); !ok {
+			c.TelemetryURL = TelemetryURL
+		}
 	}
 	if c.TelemetryInterval == "" {
 		c.TelemetryInterval = TelemetryInterval

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -23,6 +23,10 @@ type EverestConfig struct {
 	DSN      string `default:"postgres://admin:pwd@127.0.0.1:5432/postgres?sslmode=disable" envconfig:"DSN"`
 	HTTPPort int    `default:"8080" envconfig:"HTTP_PORT"`
 	Verbose  bool   `default:"false" envconfig:"VERBOSE"`
+	// TelemetryURL Everest telemetry endpoint.
+	TelemetryURL string `default:"https://check.percona.com" envconfig:"TELEMETRY_URL"`
+	// TelemetryInterval Everest telemetry sending frequency.
+	TelemetryInterval string `default:"24h" envconfig:"TELEMETRY_INTERVAL"`
 }
 
 // ParseConfig parses env vars and fills EverestConfig.

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -17,8 +17,9 @@
 package config
 
 import (
-	"github.com/kelseyhightower/envconfig"
 	"os"
+
+	"github.com/kelseyhightower/envconfig"
 )
 
 //nolint:gochecknoglobals


### PR DESCRIPTION
[![EVEREST-506](https://badgen.net/badge/JIRA/EVEREST-506/green)](https://jira.percona.com/browse/EVEREST-506) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Distinguish release builds**
---
**Problem:**
EVEREST-506

*Short explanation of the problem.*

With the current TelemetryURL configuration the test/dev data can still appear in prod telemetry (when testing dev-latest or rc builds). 

**Solution:**

Do not set the prod TelemetryURL as default. 
Set the url to the prod value _only_ when building a release image, so by default no url is set at all. 
For the testing purposes use the `make run-debug` which runs the version with the _dev_ telemetry enabled. 


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?