### PR TITLE
EVEREST-507 Report metrics

### DIFF
--- a/api/deps.go
+++ b/api/deps.go
@@ -70,6 +70,7 @@ type monitoringInstanceStorage interface {
 }
 
 type settingsStorage interface {
-	GetSettings(ctx context.Context) (*model.Settings, error)
-	CreateSettings(ctx context.Context, params model.SettingsParams) (*model.Settings, error)
+	GetEverestID(ctx context.Context) (string, error)
+	GetSettingByKey(ctx context.Context, key string) (string, error)
+	InitSettings(ctx context.Context) error
 }

--- a/api/deps.go
+++ b/api/deps.go
@@ -39,6 +39,7 @@ type storage interface {
 	backupStorageStorage
 	kubernetesClusterStorage
 	monitoringInstanceStorage
+	settingsStorage
 
 	Begin(ctx context.Context) *gorm.DB
 	Close() error
@@ -66,4 +67,9 @@ type monitoringInstanceStorage interface {
 	GetMonitoringInstance(name string) (*model.MonitoringInstance, error)
 	DeleteMonitoringInstance(name string, tx *gorm.DB) error
 	UpdateMonitoringInstance(name string, params model.UpdateMonitoringInstanceParams) error
+}
+
+type settingsStorage interface {
+	GetSettings(ctx context.Context) (*model.Settings, error)
+	CreateSettings(ctx context.Context, params model.SettingsParams) (*model.Settings, error)
 }

--- a/api/everest.go
+++ b/api/everest.go
@@ -28,7 +28,6 @@ import (
 	"sync"
 
 	"github.com/deepmap/oapi-codegen/pkg/middleware"
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 	"go.uber.org/zap"
@@ -73,7 +72,7 @@ func NewEverestServer(c *config.EverestConfig, l *zap.SugaredLogger) (*EverestSe
 
 	ctx := context.Background()
 
-	_, err = e.storage.CreateSettings(ctx, model.SettingsParams{ID: uuid.NewString()})
+	err = e.storage.InitSettings(ctx)
 	if err != nil {
 		e.l.Error(err)
 		return e, err

--- a/api/everest.go
+++ b/api/everest.go
@@ -70,25 +70,10 @@ func NewEverestServer(c *config.EverestConfig, l *zap.SugaredLogger) (*EverestSe
 		return e, err
 	}
 
-	ctx := context.Background()
-
-	err = e.storage.InitSettings(ctx)
+	err = e.storage.InitSettings(context.Background())
 	if err != nil {
 		e.l.Error(err)
 		return e, err
-	}
-
-	if !c.DisableTelemetry {
-		// To prevent leaking test data to prod,
-		// the prod TelemetryURL is set for the release builds during the build time.
-		// The dev TelemetryURL is set only when running `make run-debug`.
-		if c.TelemetryURL != "" {
-			go func() {
-				e.runTelemetryJob(ctx, c)
-			}()
-		} else {
-			e.l.Info("Telemetry is not running, the TELEMETRY_URL is not set")
-		}
 	}
 
 	return e, err

--- a/api/telemetry.go
+++ b/api/telemetry.go
@@ -15,8 +15,12 @@ import (
 	"github.com/percona/percona-everest-backend/cmd/config"
 )
 
-// TelemetryProductFamily represents telemetry product family for Everest.
-const TelemetryProductFamily = "PRODUCT_FAMILY_EVEREST"
+const (
+	telemetryProductFamily = "PRODUCT_FAMILY_EVEREST"
+
+	// delay the initial metrics to prevent flooding in case of many restarts.
+	initialMetricsDelay = 5 * time.Minute
+)
 
 // Telemetry is the struct for telemetry reports.
 type Telemetry struct {
@@ -75,7 +79,7 @@ func (e *EverestServer) RunTelemetryJob(ctx context.Context, c *config.EverestCo
 		return
 	}
 
-	timer := time.NewTimer(0)
+	timer := time.NewTimer(initialMetricsDelay)
 	defer timer.Stop()
 
 	for {
@@ -137,7 +141,7 @@ func (e *EverestServer) collectMetrics(ctx context.Context, url string) error {
 				ID:            uuid.NewString(),
 				CreateTime:    time.Now(),
 				InstanceID:    everestID,
-				ProductFamily: TelemetryProductFamily,
+				ProductFamily: telemetryProductFamily,
 				Metrics:       metrics,
 			},
 		},

--- a/api/telemetry.go
+++ b/api/telemetry.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/percona/percona-everest-backend/cmd/config"
+)
+
+// TelemetryProductFamily represents telemetry product family for Everest.
+const TelemetryProductFamily = "PRODUCT_FAMILY_EVEREST"
+
+// Telemetry is the struct for telemetry reports.
+type Telemetry struct {
+	Reports []Report `json:"reports"`
+}
+
+// Report is a struct for a single telemetry report.
+type Report struct {
+	ID            string    `json:"id"`
+	CreateTime    time.Time `json:"createTime"`
+	InstanceID    string    `json:"instanceId"`
+	ProductFamily string    `json:"productFamily"`
+	Metrics       []Metric  `json:"metrics"`
+}
+
+// Metric represents key-value metrics.
+type Metric struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (e *EverestServer) report(ctx context.Context, baseURL string, data Telemetry) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("failed to marshal the telemetry report")))
+		return err
+	}
+
+	url := fmt.Sprintf("%s/v1/telemetry/GenericReport", baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("failed to create http request")))
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("failed to send telemetry request")))
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		e.l.Info("Telemetry service responded with http status ", resp.StatusCode)
+	}
+	return nil
+}
+
+func (e *EverestServer) runTelemetryJob(ctx context.Context, c *config.EverestConfig) {
+	e.l.Debug("Starting background jobs runner.")
+
+	interval, err := time.ParseDuration(c.TelemetryInterval)
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("could not parse telemetry interval")))
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			err = e.collectMetrics(ctx, c.TelemetryURL)
+			if err != nil {
+				e.l.Error(errors.Join(err, errors.New("failed to collect telemetry data")))
+			}
+		}
+	}
+}
+
+func (e *EverestServer) collectMetrics(ctx context.Context, url string) error {
+	ks, err := e.storage.ListKubernetesClusters(ctx)
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("could not list Kubernetes clusters")))
+		return err
+	}
+	if len(ks) == 0 {
+		return nil
+	}
+	// FIXME: Revisit it once multi k8s support will be enabled
+	_, kubeClient, _, err := e.initKubeClient(ctx, ks[0].ID)
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("could not init kube client for config")))
+		return err
+	}
+
+	clusters, err := kubeClient.ListDatabaseClusters(ctx)
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("failed to list database clusters")))
+		return err
+	}
+
+	types := make(map[string]int, 3)
+	for _, cl := range clusters.Items {
+		types[string(cl.Spec.Engine.Type)]++
+	}
+
+	// key - the engine type, value - the amount of db clusters of that type
+	metrics := make([]Metric, 0, 3)
+	for key, val := range types {
+		metrics = append(metrics, Metric{key, strconv.Itoa(val)})
+	}
+
+	settings, err := e.storage.GetSettings(ctx)
+	if err != nil {
+		e.l.Error(errors.Join(err, errors.New("failed to get Everest settings")))
+		return err
+	}
+
+	report := Telemetry{
+		[]Report{
+			{
+				ID:            uuid.NewString(),
+				CreateTime:    time.Now(),
+				InstanceID:    settings.ID,
+				ProductFamily: TelemetryProductFamily,
+				Metrics:       metrics,
+			},
+		},
+	}
+
+	return e.report(ctx, url, report)
+}

--- a/api/telemetry.go
+++ b/api/telemetry.go
@@ -122,7 +122,7 @@ func (e *EverestServer) collectMetrics(ctx context.Context, url string) error {
 		metrics = append(metrics, Metric{key, strconv.Itoa(val)})
 	}
 
-	settings, err := e.storage.GetSettings(ctx)
+	everestID, err := e.storage.GetEverestID(ctx)
 	if err != nil {
 		e.l.Error(errors.Join(err, errors.New("failed to get Everest settings")))
 		return err
@@ -133,7 +133,7 @@ func (e *EverestServer) collectMetrics(ctx context.Context, url string) error {
 			{
 				ID:            uuid.NewString(),
 				CreateTime:    time.Now(),
-				InstanceID:    settings.ID,
+				InstanceID:    everestID,
 				ProductFamily: TelemetryProductFamily,
 				Metrics:       metrics,
 			},

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -16,9 +16,7 @@
 // Package config ...
 package config
 
-import (
-	"github.com/kelseyhightower/envconfig"
-)
+import "github.com/kelseyhightower/envconfig"
 
 //nolint:gochecknoglobals
 var (

--- a/migrations/000008_create_settings_table.down.sql
+++ b/migrations/000008_create_settings_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE settings;

--- a/migrations/000008_create_settings_table.up.sql
+++ b/migrations/000008_create_settings_table.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE settings
+(
+    id uuid NOT NULL PRIMARY KEY
+);

--- a/migrations/000008_create_settings_table.up.sql
+++ b/migrations/000008_create_settings_table.up.sql
@@ -1,4 +1,6 @@
 CREATE TABLE settings
 (
-    id uuid NOT NULL PRIMARY KEY
+    id     SERIAL PRIMARY KEY,
+    key    TEXT UNIQUE NOT NULL,
+    value  TEXT
 );

--- a/model/settings.go
+++ b/model/settings.go
@@ -56,9 +56,9 @@ func (db *Database) InitSettings(ctx context.Context) error {
 
 // GetSettingByKey returns Everest settings.
 func (db *Database) GetSettingByKey(_ context.Context, key string) (string, error) {
-	setting := &Setting{Key: key}
+	setting := &Setting{}
 
-	err := db.gormDB.First(&setting).Error
+	err := db.gormDB.First(&setting, "key = ?", key).Error
 	if err != nil {
 		return "", err
 	}

--- a/model/settings.go
+++ b/model/settings.go
@@ -1,0 +1,60 @@
+// percona-everest-backend
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"errors"
+)
+
+// Settings represents db model for Everest settings.
+type Settings struct {
+	ID string
+}
+
+// SettingsParams represents params for Everest settings.
+type SettingsParams struct {
+	ID string
+}
+
+// CreateSettings creates an Everest settings record.
+func (db *Database) CreateSettings(_ context.Context, params SettingsParams) (*Settings, error) {
+	s := &Settings{
+		ID: params.ID,
+	}
+	err := db.gormDB.Create(s).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// GetSettings returns Everest settings.
+func (db *Database) GetSettings(_ context.Context) (*Settings, error) {
+	var settings []Settings
+	err := db.gormDB.First(&settings).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(settings) > 1 {
+		return nil, errors.New("more than one set of settings found")
+	}
+	if len(settings) == 0 {
+		return nil, errors.New("no settings found")
+	}
+	return &settings[0], nil
+}

--- a/model/settings.go
+++ b/model/settings.go
@@ -33,12 +33,6 @@ type Setting struct {
 	Value string
 }
 
-// SettingParams represents params for Everest settings.
-type SettingParams struct {
-	Key   string
-	Value string
-}
-
 // InitSettings creates an Everest settings record.
 func (db *Database) InitSettings(ctx context.Context) error {
 	everestID, err := db.GetEverestID(ctx)


### PR DESCRIPTION
[![EVEREST-507](https://badgen.net/badge/JIRA/EVEREST-507/green)](https://jira.percona.com/browse/EVEREST-507) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Collect and report metrics**
---
**Problem:**
EVEREST-507

Report the db engines metrics - how many db clusters of each type are running. 

A step forward multi k8s support - generate own Everest ID instead of using the k8s cluster ID. 

The telemetry request [example](https://www.notion.so/percona/Pillars-Telemetry-Design-efea81c1f170456099503bbcdbd0ad9b?pvs=4#fb2130ee3a30425c9e3dd45045f34235) 


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?