### PR TITLE
EVEREST-107: Disable cgo

### DIFF
--- a/.github/workflows/rc_rebuild.yml
+++ b/.github/workflows/rc_rebuild.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Build Everest
         run: |
           cd ${GITHUB_WORKSPACE}/backend
-          GOOS=linux GOARCH=amd64 make build
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build
 
       - name: Setup docker build metadata
         uses: docker/metadata-action@v5


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-107

Disable cgo so we don't use dynamic links.

**Cause:**
`libc` is not available in `scratch` image

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?