### PR TITLE
EVEREST-107 use ClusterIP as default service type

### DIFF
--- a/deploy/quickstart-k8s.yaml
+++ b/deploy/quickstart-k8s.yaml
@@ -103,7 +103,7 @@ spec:
   selector:
     app.kubernetes.io/component: everest
     app.kubernetes.io/name: percona-everest-backend
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - protocol: TCP
       port: 8080


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-107

The current deployment to k8s uses the LoadBalancer as the default service type which exposes everest to outside the cluster.

**Solution:**
Use ClusterIP as the default service type and add documentation on how to change it.