### PR TITLE
EVEREST-559 fix version fetched by build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ./backend
+          fetch-depth: 0
 
       - name: Embed Everest Frontend app into backend
         run: |


### PR DESCRIPTION
[![EVEREST-559](https://badgen.net/badge/JIRA/EVEREST-559/green)](https://jira.percona.com/browse/EVEREST-559) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**EVEREST-559 fix version fetched by build pipeline**
---
**Problem:**
EVEREST-559

The everest version is incorrect.

**Cause:**
With the default configuration, the github actions/checkout@v4 only fetches the main branch. Without tag information git describe isn't able to get the correct version.

**Solution:**
Since we need to call git describe to get the everest version we also need to fetch the tags. Therefore, we need to set fetch-depth: 0 which fetches all history for all tags and branches.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~