### PR TITLE
EVEREST-684 Do not check backups/restores on backup storage deletion

### DIFF
--- a/api/backup_storage.go
+++ b/api/backup_storage.go
@@ -173,16 +173,6 @@ func (e *EverestServer) DeleteBackupStorage(ctx echo.Context, backupStorageName 
 			Message: pointer.ToString("Failed to delete a backup storage"),
 		})
 	}
-	if err := e.kubeClient.DeleteSecret(ctx.Request().Context(), backupStorageName); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return ctx.NoContent(http.StatusNoContent)
-		}
-		e.l.Error(err)
-		return ctx.JSON(http.StatusInternalServerError, Error{
-			Message: pointer.ToString("Failed to delete a secret for backup storage"),
-		})
-	}
-
 	return ctx.NoContent(http.StatusNoContent)
 }
 

--- a/pkg/kubernetes/backup_storage.go
+++ b/pkg/kubernetes/backup_storage.go
@@ -74,19 +74,5 @@ func (k *Kubernetes) IsBackupStorageUsed(ctx context.Context, backupStorageName 
 	if len(list.Items) > 0 {
 		return true, nil
 	}
-	bList, err := k.client.ListDatabaseClusterBackups(ctx, options)
-	if err != nil {
-		return false, err
-	}
-	if len(bList.Items) > 0 {
-		return true, nil
-	}
-	rList, err := k.client.ListDatabaseClusterRestores(ctx, options)
-	if err != nil {
-		return false, err
-	}
-	if len(rList.Items) > 0 {
-		return true, nil
-	}
 	return false, nil
 }


### PR DESCRIPTION
[![EVEREST-684](https://badgen.net/badge/JIRA/EVEREST-684/green)](https://jira.percona.com/browse/EVEREST-684) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-684

*Short explanation of the problem.*

Since we made changes in the operator and we set controller references for backupstorages there's no need to delete the secret.

Also, we do not need to check for backups/restores to indicate if the backup storage is used because they do not affect the logic of using backup storage. So, I just dropped the code

**Related pull requests**

- [link]

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?