### PR TITLE
EVEREST-737 fix wrong base backup with PITR

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/AlekSi/pointer"
 	"github.com/labstack/echo/v4"
 	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateDatabaseCluster creates a new db cluster inside the given k8s cluster.
@@ -127,7 +128,14 @@ func (e *EverestServer) GetDatabaseClusterPitr(ctx echo.Context, name string) er
 		return ctx.JSON(http.StatusOK, response)
 	}
 
-	backups, err := e.kubeClient.ListDatabaseClusterBackups(ctx.Request().Context())
+	options := metav1.ListOptions{
+		LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"clusterName": name,
+			},
+		}),
+	}
+	backups, err := e.kubeClient.ListDatabaseClusterBackups(ctx.Request().Context(), options)
 	if err != nil {
 		e.l.Error(err)
 		return ctx.JSON(http.StatusInternalServerError, Error{Message: pointer.ToString(err.Error())})

--- a/pkg/kubernetes/database_cluster_backup.go
+++ b/pkg/kubernetes/database_cluster_backup.go
@@ -28,6 +28,6 @@ func (k *Kubernetes) GetDatabaseClusterBackup(ctx context.Context, name string) 
 }
 
 // ListDatabaseClusterBackups returns database cluster backups.
-func (k *Kubernetes) ListDatabaseClusterBackups(ctx context.Context) (*everestv1alpha1.DatabaseClusterBackupList, error) {
-	return k.client.ListDatabaseClusterBackups(ctx, metav1.ListOptions{})
+func (k *Kubernetes) ListDatabaseClusterBackups(ctx context.Context, options metav1.ListOptions) (*everestv1alpha1.DatabaseClusterBackupList, error) {
+	return k.client.ListDatabaseClusterBackups(ctx, options)
 }


### PR DESCRIPTION
[![EVEREST-737](https://badgen.net/badge/JIRA/EVEREST-737/green)](https://jira.percona.com/browse/EVEREST-737) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Fix wrong base backup with PITR**
---
**Problem:**
EVEREST-737

The PITR was taking the wrong backup as a base for PITR.

**Cause:**
When searching for the latest backup we were getting all backups without any filtering.

**Solution:**
When getting the list of backups we need to filter just for the backups of the given DBC, we can use the clusterName label for that.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~

[EVEREST-737]: https://perconadev.atlassian.net/browse/EVEREST-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ