### PR TITLE
EVEREST-520-fix-validation

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -741,7 +741,7 @@ func validateDatabaseClusterBackup(ctx context.Context, backup *DatabaseClusterB
 	}
 
 	if db.Spec.Engine.Type == everestv1alpha1.DatabaseEnginePSMDB {
-		if db.Status.ActiveStorage != b.Spec.BackupStorageName {
+		if db.Status.ActiveStorage != "" && db.Status.ActiveStorage != b.Spec.BackupStorageName {
 			return errPSMDBViolateActiveStorage
 		}
 	}


### PR DESCRIPTION
**PSMDB validation fix**
---
**Problem:**
EVEREST-520

Validation wasn't working correctly when there wasn't any activeStorage. 
