### PR TITLE
EVEREST-734: do not fail on vmagent not present

### DIFF
--- a/pkg/kubernetes/monitoring_config.go
+++ b/pkg/kubernetes/monitoring_config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -87,6 +88,9 @@ func (k *Kubernetes) IsMonitoringConfigUsed(ctx context.Context, monitoringConfi
 func (k *Kubernetes) isMonitoringConfigUsedByVMAgent(ctx context.Context, name string) (bool, error) {
 	vmAgents, err := k.ListVMAgents()
 	if err != nil {
+		if errors.Is(err, &meta.NoKindMatchError{}) {
+			return false, nil
+		}
 		return false, errors.Join(err, errors.New("could not list VM agents in Kubernetes"))
 	}
 	secretNames := make([]string, 0, len(vmAgents.Items))


### PR DESCRIPTION
[![EVEREST-734](https://badgen.net/badge/JIRA/EVEREST-734/green)](https://jira.percona.com/browse/EVEREST-734) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-734

When monitoring was not enabled and VM Agent CRD was not present, a monitoring config cannot be removed.

**Solution:**
Handle missing CRD error.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?