### PR TITLE
EVEREST-781 Use databaseAdmin user in MongoDB clusters

### DIFF
--- a/api/database_cluster.go
+++ b/api/database_cluster.go
@@ -103,8 +103,8 @@ func (e *EverestServer) GetDatabaseClusterCredentials(ctx echo.Context, name str
 		response.Username = pointer.ToString("root")
 		response.Password = pointer.ToString(string(secret.Data["root"]))
 	case everestv1alpha1.DatabaseEnginePSMDB:
-		response.Username = pointer.ToString(string(secret.Data["MONGODB_USER_ADMIN_USER"]))
-		response.Password = pointer.ToString(string(secret.Data["MONGODB_USER_ADMIN_PASSWORD"]))
+		response.Username = pointer.ToString(string(secret.Data["MONGODB_DATABASE_ADMIN_USER"]))
+		response.Password = pointer.ToString(string(secret.Data["MONGODB_DATABASE_ADMIN_PASSWORD"]))
 	case everestv1alpha1.DatabaseEnginePostgresql:
 		response.Username = pointer.ToString("postgres")
 		response.Password = pointer.ToString(string(secret.Data["password"]))


### PR DESCRIPTION
[![EVEREST-781](https://badgen.net/badge/JIRA/EVEREST-781/green)](https://jira.percona.com/browse/EVEREST-781) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Use databaseAdmin user in MongoDB clusters**
---
**Problem:**
EVEREST-781

User is unauthorized for managing DBs.

**Cause:**
The `userAdmin` doesn't have permissions to manage DBs

**Solution:**
Use `databaseAdmin` user.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~

[EVEREST-781]: https://perconadev.atlassian.net/browse/EVEREST-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ