### PR TITLE
EVEREST-638 DataSource validation

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -78,6 +78,7 @@ var (
 	errDataSourceNoBackupStorageName = errors.New("'backupStorageName' should be specified in .Spec.DataSource.BackupSource")
 	errDataSourceNoPath              = errors.New("'path' should be specified in .Spec.DataSource.BackupSource")
 	errIncorrectDataSourceStruct     = errors.New("incorrect data source struct")
+	errUnsupportedPitrType           = errors.New("the given point-in-time recovery type is not supported")
 	//nolint:gochecknoglobals
 	operatorEngine = map[everestv1alpha1.EngineType]string{
 		everestv1alpha1.DatabaseEnginePXC:        pxcDeploymentName,
@@ -680,6 +681,8 @@ func validateDataSource(dataSource dataSourceStruct) error {
 			if _, err := time.Parse(dateFormat, *dataSource.Pitr.Date); err != nil {
 				return errDataSourceWrongDateFormat
 			}
+		} else {
+			return errUnsupportedPitrType
 		}
 	}
 	return nil

--- a/api/validation.go
+++ b/api/validation.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,6 +45,7 @@ const (
 	pxcDeploymentName   = "percona-xtradb-cluster-operator"
 	psmdbDeploymentName = "percona-server-mongodb-operator"
 	pgDeploymentName    = "percona-postgresql-operator"
+	dateFormat          = "2006-01-02T15:04:05Z"
 )
 
 var (
@@ -51,25 +53,30 @@ var (
 	minCPUQuantity     = resource.MustParse("600m") //nolint:gochecknoglobals
 	minMemQuantity     = resource.MustParse("512M") //nolint:gochecknoglobals
 
-	errDBCEmptyMetadata            = errors.New("databaseCluster's Metadata should not be empty")
-	errDBCNameEmpty                = errors.New("databaseCluster's metadata.name should not be empty")
-	errDBCNameWrongFormat          = errors.New("databaseCluster's metadata.name should be a string")
-	errNotEnoughMemory             = fmt.Errorf("memory limits should be above %s", minMemQuantity.String())
-	errInt64NotSupported           = errors.New("specifying resources using int64 data type is not supported. Please use string format for that")
-	errNotEnoughCPU                = fmt.Errorf("CPU limits should be above %s", minCPUQuantity.String())
-	errNotEnoughDiskSize           = fmt.Errorf("storage size should be above %s", minStorageQuantity.String())
-	errUnsupportedPXCProxy         = errors.New("you can use either HAProxy or Proxy SQL for PXC clusters")
-	errUnsupportedPGProxy          = errors.New("you can use only PGBouncer as a proxy type for Postgres clusters")
-	errUnsupportedPSMDBProxy       = errors.New("you can use only Mongos as a proxy type for MongoDB clusters")
-	errNoSchedules                 = errors.New("please specify at least one backup schedule")
-	errNoNameInSchedule            = errors.New("'name' field for the backup schedules cannot be empty")
-	errScheduleNoBackupStorageName = errors.New("'backupStorageName' field cannot be empty when schedule is enabled")
-	errPitrNoBackupStorageName     = errors.New("'backupStorageName' field cannot be empty when pitr is enabled")
-	errNoResourceDefined           = errors.New("please specify resource limits for the cluster")
-	errPitrUploadInterval          = errors.New("'uploadIntervalSec' should be more than 0")
-	errPXCPitrS3Only               = errors.New("point-in-time recovery only supported for s3 compatible storages")
-	errPSMDBMultipleStorages       = errors.New("can't use more than one backup storage for PSMDB clusters")
-	errPSMDBViolateActiveStorage   = errors.New("can't change the active storage for PSMDB clusters")
+	errDBCEmptyMetadata              = errors.New("databaseCluster's Metadata should not be empty")
+	errDBCNameEmpty                  = errors.New("databaseCluster's metadata.name should not be empty")
+	errDBCNameWrongFormat            = errors.New("databaseCluster's metadata.name should be a string")
+	errNotEnoughMemory               = fmt.Errorf("memory limits should be above %s", minMemQuantity.String())
+	errInt64NotSupported             = errors.New("specifying resources using int64 data type is not supported. Please use string format for that")
+	errNotEnoughCPU                  = fmt.Errorf("CPU limits should be above %s", minCPUQuantity.String())
+	errNotEnoughDiskSize             = fmt.Errorf("storage size should be above %s", minStorageQuantity.String())
+	errUnsupportedPXCProxy           = errors.New("you can use either HAProxy or Proxy SQL for PXC clusters")
+	errUnsupportedPGProxy            = errors.New("you can use only PGBouncer as a proxy type for Postgres clusters")
+	errUnsupportedPSMDBProxy         = errors.New("you can use only Mongos as a proxy type for MongoDB clusters")
+	errNoSchedules                   = errors.New("please specify at least one backup schedule")
+	errNoNameInSchedule              = errors.New("'name' field for the backup schedules cannot be empty")
+	errScheduleNoBackupStorageName   = errors.New("'backupStorageName' field cannot be empty when schedule is enabled")
+	errPitrNoBackupStorageName       = errors.New("'backupStorageName' field cannot be empty when pitr is enabled")
+	errNoResourceDefined             = errors.New("please specify resource limits for the cluster")
+	errPitrUploadInterval            = errors.New("'uploadIntervalSec' should be more than 0")
+	errPXCPitrS3Only                 = errors.New("point-in-time recovery only supported for s3 compatible storages")
+	errPSMDBMultipleStorages         = errors.New("can't use more than one backup storage for PSMDB clusters")
+	errPSMDBViolateActiveStorage     = errors.New("can't change the active storage for PSMDB clusters")
+	errDataSourceConfig              = errors.New("either DBClusterBackupName or BackupSource must be specified in the DataSource field")
+	errDataSourceNoPitrDateSpecified = errors.New("pitr Date must be specified for type Date")
+	errDataSourceWrongDateFormat     = errors.New("failed to parse .Spec.DataSource.Pitr.Date as 2006-01-02T15:04:05Z")
+	errDataSourceNoBackupStorageName = errors.New("'backupStorageName' should be specified in .Spec.DataSource.BackupSource")
+	errDataSourceNoPath              = errors.New("'path' should be specified in .Spec.DataSource.BackupSource")
 	//nolint:gochecknoglobals
 	operatorEngine = map[everestv1alpha1.EngineType]string{
 		everestv1alpha1.DatabaseEnginePXC:        pxcDeploymentName,
@@ -409,7 +416,7 @@ func validateCreateDatabaseClusterRequest(dbc DatabaseCluster) error {
 	return validateRFC1035(strName, "metadata.name")
 }
 
-func (e *EverestServer) validateDatabaseClusterCR(ctx echo.Context, databaseCluster *DatabaseCluster) error {
+func (e *EverestServer) validateDatabaseClusterCR(ctx echo.Context, databaseCluster *DatabaseCluster) error { //nolint:cyclop
 	if err := validateCreateDatabaseClusterRequest(*databaseCluster); err != nil {
 		return err
 	}
@@ -443,6 +450,10 @@ func (e *EverestServer) validateDatabaseClusterCR(ctx echo.Context, databaseClus
 	}
 
 	if err = validateBackupStoragesFor(ctx.Request().Context(), databaseCluster, e.validateBackupStoragesAccess); err != nil {
+		return err
+	}
+
+	if err := validateDataSource(databaseCluster); err != nil {
 		return err
 	}
 
@@ -613,6 +624,40 @@ func validateResourceLimits(cluster *DatabaseCluster) error {
 		return err
 	}
 	return validateStorageSize(cluster)
+}
+
+func validateDataSource(db *DatabaseCluster) error {
+	if db.Spec.DataSource == nil {
+		return nil
+	}
+
+	if (db.Spec.DataSource.DbClusterBackupName == nil && db.Spec.DataSource.BackupSource == nil) ||
+		(db.Spec.DataSource.DbClusterBackupName != nil && *db.Spec.DataSource.DbClusterBackupName != "" && db.Spec.DataSource.BackupSource != nil) {
+		return errDataSourceConfig
+	}
+
+	if db.Spec.DataSource.BackupSource != nil {
+		if db.Spec.DataSource.BackupSource.BackupStorageName == "" {
+			return errDataSourceNoBackupStorageName
+		}
+
+		if db.Spec.DataSource.BackupSource.Path == "" {
+			return errDataSourceNoPath
+		}
+	}
+
+	if db.Spec.DataSource.Pitr != nil { //nolint:nestif
+		if db.Spec.DataSource.Pitr.Type == nil || *db.Spec.DataSource.Pitr.Type == DatabaseClusterSpecDataSourcePitrTypeDate {
+			if db.Spec.DataSource.Pitr.Date == nil {
+				return errDataSourceNoPitrDateSpecified
+			}
+
+			if _, err := time.Parse(dateFormat, *db.Spec.DataSource.Pitr.Date); err != nil {
+				return errDataSourceWrongDateFormat
+			}
+		}
+	}
+	return nil
 }
 
 func ensureNonEmptyResources(cluster *DatabaseCluster) error {

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -698,9 +698,9 @@ func TestValidateDataSource(t *testing.T) {
 			err:     nil,
 		},
 		{
-			name:    "correct with latest and backup source",
+			name:    "unsupported pitr type",
 			cluster: []byte(`{"backupSource":{"backupStorageName":"some-name","path":"some-path"},"pitr":{"type":"latest"}}`),
-			err:     nil,
+			err:     errUnsupportedPitrType,
 		},
 	}
 	for _, tc := range cases {

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -512,7 +512,7 @@ func TestValidateBackupStoragesFor(t *testing.T) {
 	}
 }
 
-func TestValidatePitrSpec(t *testing.T) {
+func TestValidatePitrSpec(t *testing.T) { //nolint:dupl
 	t.Parallel()
 
 	cases := []struct {
@@ -573,6 +573,7 @@ func TestValidatePitrSpec(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
+			require.Error(t, err)
 			assert.Equal(t, err.Error(), tc.err.Error())
 		})
 	}
@@ -648,6 +649,73 @@ func TestValidateResourceLimits(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
+			require.Error(t, err)
+			assert.Equal(t, err.Error(), tc.err.Error())
+		})
+	}
+}
+
+func TestValidateDataSource(t *testing.T) { //nolint:dupl
+	t.Parallel()
+	cases := []struct {
+		name    string
+		cluster []byte
+		err     error
+	}{
+		{
+			name:    "err none of the data source specified",
+			cluster: []byte(`{"spec":{"dataSource":{}}}`),
+			err:     errDataSourceConfig,
+		},
+		{
+			name:    "err both of the data source specified",
+			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup", "backupSource": {"backupStorageName":"some-name","path":"some-path"}}}}`),
+			err:     errDataSourceConfig,
+		},
+		{
+			name:    "err no date in pitr",
+			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{}}}}`),
+			err:     errDataSourceNoPitrDateSpecified,
+		},
+		{
+			name:    "wrong pitr date format",
+			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"date":"2006-06-07 14:06:07"}}}}`),
+			err:     errDataSourceWrongDateFormat,
+		},
+		{
+			name:    "wrong pitr date format",
+			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"date":""}}}}`),
+			err:     errDataSourceWrongDateFormat,
+		},
+		{
+			name:    "correct minimal",
+			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"date":"2006-06-07T14:06:07Z"}}}}`),
+			err:     nil,
+		},
+		{
+			name:    "correct with pitr type",
+			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"type":"date","date":"2006-06-07T14:06:07Z"}}}}`),
+			err:     nil,
+		},
+		{
+			name:    "correct with latest and backup source",
+			cluster: []byte(`{"spec":{"dataSource":{"backupSource":{"backupStorageName":"some-name","path":"some-path"},"pitr":{"type":"latest"}}}}`),
+			err:     nil,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cluster := &DatabaseCluster{}
+			err := json.Unmarshal(tc.cluster, cluster)
+			require.NoError(t, err)
+			err = validateDataSource(cluster)
+			if tc.err == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
 			assert.Equal(t, err.Error(), tc.err.Error())
 		})
 	}

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -512,7 +512,7 @@ func TestValidateBackupStoragesFor(t *testing.T) {
 	}
 }
 
-func TestValidatePitrSpec(t *testing.T) { //nolint:dupl
+func TestValidatePitrSpec(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -655,7 +655,7 @@ func TestValidateResourceLimits(t *testing.T) {
 	}
 }
 
-func TestValidateDataSource(t *testing.T) { //nolint:dupl
+func TestValidateDataSource(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name    string
@@ -664,42 +664,42 @@ func TestValidateDataSource(t *testing.T) { //nolint:dupl
 	}{
 		{
 			name:    "err none of the data source specified",
-			cluster: []byte(`{"spec":{"dataSource":{}}}`),
+			cluster: []byte(`{}`),
 			err:     errDataSourceConfig,
 		},
 		{
 			name:    "err both of the data source specified",
-			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup", "backupSource": {"backupStorageName":"some-name","path":"some-path"}}}}`),
+			cluster: []byte(`{"dbClusterBackupName":"some-backup", "backupSource": {"backupStorageName":"some-name","path":"some-path"}}`),
 			err:     errDataSourceConfig,
 		},
 		{
 			name:    "err no date in pitr",
-			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{}}}}`),
+			cluster: []byte(`{"dbClusterBackupName":"some-backup","pitr":{}}`),
 			err:     errDataSourceNoPitrDateSpecified,
 		},
 		{
 			name:    "wrong pitr date format",
-			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"date":"2006-06-07 14:06:07"}}}}`),
+			cluster: []byte(`{"dbClusterBackupName":"some-backup","pitr":{"date":"2006-06-07 14:06:07"}}`),
 			err:     errDataSourceWrongDateFormat,
 		},
 		{
 			name:    "wrong pitr date format",
-			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"date":""}}}}`),
+			cluster: []byte(`{"dbClusterBackupName":"some-backup","pitr":{"date":""}}`),
 			err:     errDataSourceWrongDateFormat,
 		},
 		{
 			name:    "correct minimal",
-			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"date":"2006-06-07T14:06:07Z"}}}}`),
+			cluster: []byte(`{"dbClusterBackupName":"some-backup","pitr":{"date":"2006-06-07T14:06:07Z"}}`),
 			err:     nil,
 		},
 		{
 			name:    "correct with pitr type",
-			cluster: []byte(`{"spec":{"dataSource":{"dbClusterBackupName":"some-backup","pitr":{"type":"date","date":"2006-06-07T14:06:07Z"}}}}`),
+			cluster: []byte(`{"dbClusterBackupName":"some-backup","pitr":{"type":"date","date":"2006-06-07T14:06:07Z"}}`),
 			err:     nil,
 		},
 		{
 			name:    "correct with latest and backup source",
-			cluster: []byte(`{"spec":{"dataSource":{"backupSource":{"backupStorageName":"some-name","path":"some-path"},"pitr":{"type":"latest"}}}}`),
+			cluster: []byte(`{"backupSource":{"backupStorageName":"some-name","path":"some-path"},"pitr":{"type":"latest"}}`),
 			err:     nil,
 		},
 	}
@@ -707,10 +707,10 @@ func TestValidateDataSource(t *testing.T) { //nolint:dupl
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			cluster := &DatabaseCluster{}
-			err := json.Unmarshal(tc.cluster, cluster)
+			dsDB := &dataSourceStruct{}
+			err := json.Unmarshal(tc.cluster, dsDB)
 			require.NoError(t, err)
-			err = validateDataSource(cluster)
+			err = validateDataSource(*dsDB)
 			if tc.err == nil {
 				require.NoError(t, err)
 				return

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/labstack/echo/v4 v4.11.3
 	github.com/oapi-codegen/echo-middleware v1.0.1
 	github.com/oapi-codegen/runtime v1.1.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20240119104008-aeb868d82769
+	github.com/percona/everest-operator v0.6.0-dev1.0.20240125150540-298621412982
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8P
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240119104008-aeb868d82769 h1:IrF61ks3spy9i7r7C94pcHGwf1HL1R4+pLP9rnU0g3s=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240119104008-aeb868d82769/go.mod h1:o84NcJlAImYMpKK9+PIjS4V8SSREt1uZOqNhHt5qXMg=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240125150540-298621412982 h1:rb3XM3Ce544WoX1Z41E7R0sL4KFEuidn0fYRhHen6Lg=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240125150540-298621412982/go.mod h1:o84NcJlAImYMpKK9+PIjS4V8SSREt1uZOqNhHt5qXMg=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/percona/percona-postgresql-operator v0.0.0-20231220140959-ad5eef722609 h1:+UOK4gcHrRgqjo4smgfwT7/0apF6PhAJdQIdAV4ub/M=


### PR DESCRIPTION
[![EVEREST-638](https://badgen.net/badge/JIRA/EVEREST-638/green)](https://jira.percona.com/browse/EVEREST-638) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-638

Added validation for DataSource in `DatabaseCluster` and `DatabaseClusterRestore`

**Related pull requests**

- https://github.com/percona/everest-operator/pull/258

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
~~- [ ] Is an Integration test/test case added for the new feature/change?~~
- [x] Are unit tests added where appropriate?

[EVEREST-638]: https://perconadev.atlassian.net/browse/EVEREST-638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ