### PR TITLE
EVEREST-539 Fix editing of backup storage

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -260,11 +260,13 @@ func validateUpdateBackupStorageRequest(ctx echo.Context, bs *everestv1alpha1.Ba
 		return nil, err
 	}
 
+	url := &bs.Spec.EndpointURL
 	if params.Url != nil {
 		if ok := validateURL(*params.Url); !ok {
 			err := ErrInvalidURL("url")
 			return nil, err
 		}
+		url = params.Url
 	}
 	accessKey := string(secret.Data["AWS_ACCESS_KEY_ID"])
 	if params.AccessKey != nil {
@@ -279,12 +281,16 @@ func validateUpdateBackupStorageRequest(ctx echo.Context, bs *everestv1alpha1.Ba
 	if params.BucketName != nil {
 		bucketName = *params.BucketName
 	}
+	region := bs.Spec.Region
+	if params.Region != nil {
+		region = *params.Region
+	}
 	switch string(bs.Spec.Type) {
 	case string(BackupStorageTypeS3):
 		if params.Region != nil && *params.Region == "" {
 			return nil, errors.New("region is required when using S3 storage type")
 		}
-		if err := s3Access(l, &bs.Spec.EndpointURL, accessKey, secretKey, bucketName, bs.Spec.Region); err != nil {
+		if err := s3Access(l, url, accessKey, secretKey, bucketName, region); err != nil {
 			return nil, err
 		}
 	case string(BackupStorageTypeAzure):

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/labstack/echo/v4 v4.11.3
 	github.com/oapi-codegen/echo-middleware v1.0.1
 	github.com/oapi-codegen/runtime v1.1.0
-	github.com/percona/everest-operator v0.6.0-dev1.0.20240125162053-e43000fbf0b8
+	github.com/percona/everest-operator v0.6.0-dev1.0.20240201153051-79f428e0c869
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8P
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240125162053-e43000fbf0b8 h1:nXu+L8fCl+vb9i24zqBCA5AjOMeeEGBn6M/KqWlmrCM=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240125162053-e43000fbf0b8/go.mod h1:o84NcJlAImYMpKK9+PIjS4V8SSREt1uZOqNhHt5qXMg=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240201153051-79f428e0c869 h1:lJlpwTRpRWJ9H6LuEUNHBO5K6oI0h8oghtp5pXIcXG0=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240201153051-79f428e0c869/go.mod h1:o84NcJlAImYMpKK9+PIjS4V8SSREt1uZOqNhHt5qXMg=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/percona/percona-postgresql-operator v0.0.0-20231220140959-ad5eef722609 h1:+UOK4gcHrRgqjo4smgfwT7/0apF6PhAJdQIdAV4ub/M=


### PR DESCRIPTION
[![EVEREST-539](https://badgen.net/badge/JIRA/EVEREST-539/green)](https://jira.percona.com/browse/EVEREST-539) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Fix editing of backup storage**
---
**Problem:**
EVEREST-539

Users are unable to update a backup storage if they try to change the region or endpointURL.

**Cause:**
We weren't getting the region and endpointURL from the request.

**Solution:**
Get both of those values from the request

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~

[EVEREST-539]: https://perconadev.atlassian.net/browse/EVEREST-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ