### PR TITLE
EVEREST-107 update api-tests for multinamespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,22 +366,6 @@ jobs:
           # API_TOKEN is used later by "make test"
           echo "API_TOKEN=$(./bin/everest token reset --json | jq .token -r)" >> $GITHUB_ENV
 
-      - name: Provision monitoring
-        shell: bash
-        continue-on-error: true
-        run: |
-          cd percona-everest-cli
-
-          while true; do kubectl port-forward -n everest-system deployment/percona-everest 8080:8080; done &
-
-          sleep 2
-
-          ./bin/everest monitoring enable \
-            --everest-url http://127.0.0.1:8080 \
-            --everest-token $API_TOKEN \
-            --instance-name pmm-local \
-            --skip-wizard
-
 
       - name: Patch Everest Deployment to use the PR image
         run: |

--- a/api-tests/tests/auth.spec.ts
+++ b/api-tests/tests/auth.spec.ts
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { expect, test } from '@fixtures'
+import {checkError} from "@tests/tests/helpers";
 
 test('auth header fails with invalid token', async ({ request }) => {
   const version = await request.get('/v1/version', {
@@ -30,7 +31,8 @@ test('auth header is preferred over cookie', async ({ browser }) => {
   const request = ctx.request
 
   const version = await request.get('/v1/version')
-  expect(version.ok()).toBeTruthy()
+  await checkError(version)
+
 })
 
 test.describe('no authorization header', () => {
@@ -67,6 +69,6 @@ test.describe('no authorization header', () => {
     const request = ctx.request
   
     const version = await request.get('/v1/version')
-    expect(version.ok()).toBeTruthy()
+    await checkError(version)
   })
 })

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -27,7 +27,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         secretKey: 'sdfsdfsd',
     }
 
-    const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+    const response = await request.post(`/v1/backup-storages`, {
         data: payload,
     })
 
@@ -45,7 +45,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     expect(created.description).toBe(payload.description)
 
     // list
-    const listResponse = await request.get(`/v1/namespaces/${testsNs}/backup-storages`)
+    const listResponse = await request.get(`/v1/backup-storages`)
 
     expect(listResponse.ok()).toBeTruthy()
     const list = await listResponse.json()
@@ -53,7 +53,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     expect(list.length).toBeGreaterThan(0)
 
     // get
-    const one = await request.get(`/v1/namespaces/${testsNs}/backup-storages${name}`)
+    const one = await request.get(`/v1/backup-storages${name}`)
 
     expect(one.ok()).toBeTruthy()
     expect((await one.json()).name).toBe(payload.name)
@@ -65,7 +65,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         accessKey: 'otherAccessKey',
         secretKey: 'otherSecret',
     }
-    const updated = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+    const updated = await request.patch(`/v1/backup-storages/${name}`, {
         data: updatePayload,
     })
 
@@ -78,14 +78,14 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     expect(result.description).toBe(updatePayload.description)
 
     // backup storage already exists
-    const createAgain = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+    const createAgain = await request.post(`/v1/backup-storages`, {
         data: payload,
     })
 
     expect(createAgain.status()).toBe(409)
 
     // delete
-    const deleted = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+    const deleted = await request.delete(`/v1/backup-storages/${name}`)
 
     expect(deleted.ok()).toBeTruthy()
 })
@@ -100,7 +100,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
         secretKey: 'sdfsdfsd',
     }
 
-    const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+    const response = await request.post(`/v1/backup-storages`, {
         data: payload,
     })
 
@@ -116,7 +116,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
     expect(created.description).toBe(payload.description)
 
     // list
-    const listResponse = await request.get(`/v1/namespaces/${testsNs}/backup-storages`)
+    const listResponse = await request.get(`/v1/backup-storages`)
 
     expect(listResponse.ok()).toBeTruthy()
     const list = await listResponse.json()
@@ -124,7 +124,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
     expect(list.length).toBeGreaterThan(0)
 
     // get
-    const one = await request.get(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+    const one = await request.get(`/v1/backup-storages/${name}`)
 
     expect(one.ok()).toBeTruthy()
     expect((await one.json()).name).toBe(payload.name)
@@ -134,7 +134,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
         description: 'some description',
         bucketName: 'percona-test-backup-storage1',
     }
-    const updated = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+    const updated = await request.patch(`/v1/backup-storages/${name}`, {
         data: updatePayload,
     })
 
@@ -147,14 +147,14 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
     expect(result.description).toBe(updatePayload.description)
 
     // backup storage already exists
-    const createAgain = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+    const createAgain = await request.post(`/v1/backup-storages`, {
         data: payload,
     })
 
     expect(createAgain.status()).toBe(409)
 
     // delete
-    const deleted = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+    const deleted = await request.delete(`/v1/backup-storages/${name}`)
 
     expect(deleted.ok()).toBeTruthy()
 })
@@ -222,7 +222,7 @@ test('create backup storage failures', async ({request}) => {
     ]
 
     for (const testCase of testCases) {
-        const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+        const response = await request.post(`/v1/backup-storages`, {
             data: testCase.payload,
         })
 
@@ -240,7 +240,7 @@ test('update backup storage failures', async ({request}) => {
         accessKey: 'sdfsdfs',
         secretKey: 'lkdfslsldfka',
     }
-    const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+    const response = await request.post(`/v1/backup-storages`, {
         data: createPayload,
     })
 
@@ -265,7 +265,7 @@ test('update backup storage failures', async ({request}) => {
     ]
 
     for (const testCase of testCases) {
-        const response = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+        const response = await request.patch(`/v1/backup-storages/${name}`, {
             data: testCase.payload,
         })
 
@@ -273,7 +273,7 @@ test('update backup storage failures', async ({request}) => {
         expect(response.status()).toBe(400)
     }
 
-    const deleted = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+    const deleted = await request.delete(`/v1/backup-storages/${name}`)
 
     expect(deleted.ok()).toBeTruthy()
 })
@@ -281,7 +281,7 @@ test('update backup storage failures', async ({request}) => {
 test('update: backup storage not found', async ({request}) => {
     const name = 'some-storage'
 
-    const response = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+    const response = await request.patch(`/v1/backup-storages/${name}`, {
         data: {
             bucketName: 's3',
         },
@@ -293,14 +293,14 @@ test('update: backup storage not found', async ({request}) => {
 test('delete: backup storage not found', async ({request}) => {
     const name = 'backup-storage'
 
-    const response = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+    const response = await request.delete(`/v1/backup-storages/${name}`)
 
     expect(response.status()).toBe(404)
 })
 
 test('get: backup storage not found', async ({request}) => {
     const name = 'backup-storage'
-    const response = await request.get(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+    const response = await request.get(`/v1/backup-storages/${name}`)
 
     expect(response.status()).toBe(404)
 })

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -25,6 +25,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         region: 'us-east-2',
         accessKey: 'sdfs',
         secretKey: 'sdfsdfsd',
+        targetNamespaces: testsNs
     }
 
     const response = await request.post(`/v1/backup-storages`, {
@@ -64,6 +65,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         bucketName: 'percona-test-backup-storage1',
         accessKey: 'otherAccessKey',
         secretKey: 'otherSecret',
+        targetNamespaces: testsNs
     }
     const updated = await request.patch(`/v1/backup-storages/${name}`, {
         data: updatePayload,
@@ -98,6 +100,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
         bucketName: 'percona-test-backup-storage',
         accessKey: 'sdfs',
         secretKey: 'sdfsdfsd',
+        targetNamespaces: testsNs
     }
 
     const response = await request.post(`/v1/backup-storages`, {
@@ -183,6 +186,7 @@ test('create backup storage failures', async ({request}) => {
                 region: 'us-east-2',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
+                targetNamespaces: testsNs
             },
             errorText: '\'name\' is not RFC 1035 compatible',
         },
@@ -195,6 +199,7 @@ test('create backup storage failures', async ({request}) => {
                 region: 'us-east-2',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
+                targetNamespaces: testsNs
             },
             errorText: '\'url\' is an invalid URL',
         },
@@ -205,6 +210,7 @@ test('create backup storage failures', async ({request}) => {
                 bucketName: 'invalid',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
+                targetNamespaces: testsNs
             },
             errorText: 'Region is required',
         },
@@ -216,6 +222,7 @@ test('create backup storage failures', async ({request}) => {
                 bucketName: 'invalid',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
+                targetNamespaces: testsNs
             },
             errorText: '"/type": value is not one of the allowed values',
         },
@@ -239,6 +246,7 @@ test('update backup storage failures', async ({request}) => {
         region: 'us-east-2',
         accessKey: 'sdfsdfs',
         secretKey: 'lkdfslsldfka',
+        targetNamespaces: testsNs
     }
     const response = await request.post(`/v1/backup-storages`, {
         data: createPayload,

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -14,11 +14,12 @@
 // limitations under the License.
 import {expect, test} from '@fixtures'
 import {checkError, testsNs} from './helpers'
+import {testPrefix} from "@tests/tests/database-cluster.spec";
 
 test('add/list/get/delete s3 backup storage success', async ({request}) => {
     const payload = {
         type: 's3',
-        name: 'backup-storage-1',
+        name: `${testPrefix}-backup-storage`,
         url: 'http://custom-url',
         description: 'Dev storage',
         bucketName: 'percona-test-backup-storage',
@@ -54,7 +55,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     expect(list.length).toBeGreaterThan(0)
 
     // get
-    const one = await request.get(`/v1/backup-storages${name}`)
+    const one = await request.get(`/v1/backup-storages/${name}`)
 
     await checkError(one)
     expect((await one.json()).name).toBe(payload.name)

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {expect, test} from '@fixtures'
-import {checkError, testsNs} from './helpers'
-import {testPrefix} from "@tests/tests/database-cluster.spec";
+import {checkError, testsNs, testPrefix} from './helpers'
 
 test('add/list/get/delete s3 backup storage success', async ({request}) => {
     const payload = {

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -12,294 +12,295 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { expect, test } from '@fixtures'
+import {expect, test} from '@fixtures'
+import {testsNs} from './helpers'
 
-test('add/list/get/delete s3 backup storage success', async ({ request }) => {
-  const payload = {
-    type: 's3',
-    name: 'backup-storage-1',
-    url: 'http://custom-url',
-    description: 'Dev storage',
-    bucketName: 'percona-test-backup-storage',
-    region: 'us-east-2',
-    accessKey: 'sdfs',
-    secretKey: 'sdfsdfsd',
-  }
-
-  const response = await request.post('/v1/backup-storages', {
-    data: payload,
-  })
-
-  // create
-  expect(response.ok()).toBeTruthy()
-  const created = await response.json()
-
-  const name = created.name
-
-  expect(created.name).toBe(payload.name)
-  expect(created.url).toBe(payload.url)
-  expect(created.bucketName).toBe(payload.bucketName)
-  expect(created.region).toBe(payload.region)
-  expect(created.type).toBe(payload.type)
-  expect(created.description).toBe(payload.description)
-
-  // list
-  const listResponse = await request.get('/v1/backup-storages')
-
-  expect(listResponse.ok()).toBeTruthy()
-  const list = await listResponse.json()
-
-  expect(list.length).toBeGreaterThan(0)
-
-  // get
-  const one = await request.get(`/v1/backup-storages/${name}`)
-
-  expect(one.ok()).toBeTruthy()
-  expect((await one.json()).name).toBe(payload.name)
-
-  // update
-  const updatePayload = {
-    description: 'some description',
-    bucketName: 'percona-test-backup-storage1',
-    accessKey: 'otherAccessKey',
-    secretKey: 'otherSecret',
-  }
-  const updated = await request.patch(`/v1/backup-storages/${name}`, {
-    data: updatePayload,
-  })
-
-  expect(updated.ok()).toBeTruthy()
-  const result = await updated.json()
-
-  expect(result.bucketName).toBe(updatePayload.bucketName)
-  expect(result.region).toBe(created.region)
-  expect(result.type).toBe(created.type)
-  expect(result.description).toBe(updatePayload.description)
-
-  // backup storage already exists
-  const createAgain = await request.post('/v1/backup-storages', {
-    data: payload,
-  })
-
-  expect(createAgain.status()).toBe(409)
-
-  // delete
-  const deleted = await request.delete(`/v1/backup-storages/${name}`)
-
-  expect(deleted.ok()).toBeTruthy()
-})
-
-test('add/list/get/delete azure backup storage success', async ({ request }) => {
-  const payload = {
-    type: 'azure',
-    name: 'backup-storage-azure',
-    description: 'Dev storage',
-    bucketName: 'percona-test-backup-storage',
-    accessKey: 'sdfs',
-    secretKey: 'sdfsdfsd',
-  }
-
-  const response = await request.post('/v1/backup-storages', {
-    data: payload,
-  })
-
-  // create
-  expect(response.ok()).toBeTruthy()
-  const created = await response.json()
-
-  const name = created.name
-
-  expect(created.name).toBe(payload.name)
-  expect(created.bucketName).toBe(payload.bucketName)
-  expect(created.type).toBe(payload.type)
-  expect(created.description).toBe(payload.description)
-
-  // list
-  const listResponse = await request.get('/v1/backup-storages')
-
-  expect(listResponse.ok()).toBeTruthy()
-  const list = await listResponse.json()
-
-  expect(list.length).toBeGreaterThan(0)
-
-  // get
-  const one = await request.get(`/v1/backup-storages/${name}`)
-
-  expect(one.ok()).toBeTruthy()
-  expect((await one.json()).name).toBe(payload.name)
-
-  // update
-  const updatePayload = {
-    description: 'some description',
-    bucketName: 'percona-test-backup-storage1',
-  }
-  const updated = await request.patch(`/v1/backup-storages/${name}`, {
-    data: updatePayload,
-  })
-
-  expect(updated.ok()).toBeTruthy()
-  const result = await updated.json()
-
-  expect(result.bucketName).toBe(updatePayload.bucketName)
-  expect(result.region).toBe(created.region)
-  expect(result.type).toBe(created.type)
-  expect(result.description).toBe(updatePayload.description)
-
-  // backup storage already exists
-  const createAgain = await request.post('/v1/backup-storages', {
-    data: payload,
-  })
-
-  expect(createAgain.status()).toBe(409)
-
-  // delete
-  const deleted = await request.delete(`/v1/backup-storages/${name}`)
-
-  expect(deleted.ok()).toBeTruthy()
-})
-
-test('create backup storage failures', async ({ request }) => {
-  const testCases = [
-    {
-      payload: {},
-      errorText: 'property \"name\" is missing',
-    },
-    {
-      payload: {
+test('add/list/get/delete s3 backup storage success', async ({request}) => {
+    const payload = {
         type: 's3',
-        name: 'backup-storage',
+        name: 'backup-storage-1',
+        url: 'http://custom-url',
+        description: 'Dev storage',
         bucketName: 'percona-test-backup-storage',
         region: 'us-east-2',
-        accessKey: 'ssdssd',
-      },
-      errorText: 'property \"secretKey\" is missing',
-    },
-    {
-      payload: {
-        type: 's3',
-        name: 'Backup Name',
-        bucketName: 'percona-test-backup-storage',
-        region: 'us-east-2',
-        accessKey: 'ssdssd',
-        secretKey: 'ssdssdssdssd',
-      },
-      errorText: '\'name\' is not RFC 1035 compatible',
-    },
-    {
-      payload: {
-        type: 's3',
-        name: 'backup',
-        bucketName: 'percona-test-backup-storage',
-        url: 'not-valid-url',
-        region: 'us-east-2',
-        accessKey: 'ssdssd',
-        secretKey: 'ssdssdssdssd',
-      },
-      errorText: '\'url\' is an invalid URL',
-    },
-    {
-      payload: {
-        type: 's3',
-        name: 'missing-region',
-        bucketName: 'invalid',
-        accessKey: 'ssdssd',
-        secretKey: 'ssdssdssdssd',
-      },
-      errorText: 'Region is required',
-    },
-    {
-      payload: {
-        type: 'gcs',
-        name: 'invalid',
-        region: 'us-east-2',
-        bucketName: 'invalid',
-        accessKey: 'ssdssd',
-        secretKey: 'ssdssdssdssd',
-      },
-      errorText: '"/type": value is not one of the allowed values',
-    },
-  ]
+        accessKey: 'sdfs',
+        secretKey: 'sdfsdfsd',
+    }
 
-  for (const testCase of testCases) {
-    const response = await request.post('/v1/backup-storages', {
-      data: testCase.payload,
+    const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+        data: payload,
     })
 
-    expect(response.status()).toBe(400)
-    expect((await response.json()).message).toMatch(testCase.errorText)
-  }
-})
+    // create
+    expect(response.ok()).toBeTruthy()
+    const created = await response.json()
 
-test('update backup storage failures', async ({ request }) => {
-  const createPayload = {
-    type: 's3',
-    name: 'backup-storage-2',
-    bucketName: 'percona-test-backup-storage',
-    region: 'us-east-2',
-    accessKey: 'sdfsdfs',
-    secretKey: 'lkdfslsldfka',
-  }
-  const response = await request.post('/v1/backup-storages', {
-    data: createPayload,
-  })
+    const name = created.name
 
-  expect(response.ok()).toBeTruthy()
-  const created = await response.json()
+    expect(created.name).toBe(payload.name)
+    expect(created.url).toBe(payload.url)
+    expect(created.bucketName).toBe(payload.bucketName)
+    expect(created.region).toBe(payload.region)
+    expect(created.type).toBe(payload.type)
+    expect(created.description).toBe(payload.description)
 
-  const name = created.name
+    // list
+    const listResponse = await request.get(`/v1/namespaces/${testsNs}/backup-storages`)
 
-  const testCases = [
-    {
-      payload: {
-        url: '-asldf;asdfk;sadf',
-      },
-      errorText: '\'url\' is an invalid URL',
-    },
-    {
-      payload: {
-        bucket: '-asldf;asdfk;sadf',
-      },
-      errorText: 'request body has an error: doesn\'t match schema #/components/schemas/UpdateBackupStorageParams: property \"bucket\" is unsupported',
-    },
-  ]
+    expect(listResponse.ok()).toBeTruthy()
+    const list = await listResponse.json()
 
-  for (const testCase of testCases) {
-    const response = await request.patch(`/v1/backup-storages/${name}`, {
-      data: testCase.payload,
+    expect(list.length).toBeGreaterThan(0)
+
+    // get
+    const one = await request.get(`/v1/namespaces/${testsNs}/backup-storages${name}`)
+
+    expect(one.ok()).toBeTruthy()
+    expect((await one.json()).name).toBe(payload.name)
+
+    // update
+    const updatePayload = {
+        description: 'some description',
+        bucketName: 'percona-test-backup-storage1',
+        accessKey: 'otherAccessKey',
+        secretKey: 'otherSecret',
+    }
+    const updated = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+        data: updatePayload,
     })
 
-    expect((await response.json()).message).toMatch(testCase.errorText)
-    expect(response.status()).toBe(400)
-  }
+    expect(updated.ok()).toBeTruthy()
+    const result = await updated.json()
 
-  const deleted = await request.delete(`/v1/backup-storages/${name}`)
+    expect(result.bucketName).toBe(updatePayload.bucketName)
+    expect(result.region).toBe(created.region)
+    expect(result.type).toBe(created.type)
+    expect(result.description).toBe(updatePayload.description)
 
-  expect(deleted.ok()).toBeTruthy()
+    // backup storage already exists
+    const createAgain = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+        data: payload,
+    })
+
+    expect(createAgain.status()).toBe(409)
+
+    // delete
+    const deleted = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+
+    expect(deleted.ok()).toBeTruthy()
 })
 
-test('update: backup storage not found', async ({ request }) => {
-  const name = 'some-storage'
+test('add/list/get/delete azure backup storage success', async ({request}) => {
+    const payload = {
+        type: 'azure',
+        name: 'backup-storage-azure',
+        description: 'Dev storage',
+        bucketName: 'percona-test-backup-storage',
+        accessKey: 'sdfs',
+        secretKey: 'sdfsdfsd',
+    }
 
-  const response = await request.patch(`/v1/backup-storages/${name}`, {
-    data: {
-      bucketName: 's3',
-    },
-  })
+    const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+        data: payload,
+    })
 
-  expect(response.status()).toBe(404)
+    // create
+    expect(response.ok()).toBeTruthy()
+    const created = await response.json()
+
+    const name = created.name
+
+    expect(created.name).toBe(payload.name)
+    expect(created.bucketName).toBe(payload.bucketName)
+    expect(created.type).toBe(payload.type)
+    expect(created.description).toBe(payload.description)
+
+    // list
+    const listResponse = await request.get(`/v1/namespaces/${testsNs}/backup-storages`)
+
+    expect(listResponse.ok()).toBeTruthy()
+    const list = await listResponse.json()
+
+    expect(list.length).toBeGreaterThan(0)
+
+    // get
+    const one = await request.get(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+
+    expect(one.ok()).toBeTruthy()
+    expect((await one.json()).name).toBe(payload.name)
+
+    // update
+    const updatePayload = {
+        description: 'some description',
+        bucketName: 'percona-test-backup-storage1',
+    }
+    const updated = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+        data: updatePayload,
+    })
+
+    expect(updated.ok()).toBeTruthy()
+    const result = await updated.json()
+
+    expect(result.bucketName).toBe(updatePayload.bucketName)
+    expect(result.region).toBe(created.region)
+    expect(result.type).toBe(created.type)
+    expect(result.description).toBe(updatePayload.description)
+
+    // backup storage already exists
+    const createAgain = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+        data: payload,
+    })
+
+    expect(createAgain.status()).toBe(409)
+
+    // delete
+    const deleted = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+
+    expect(deleted.ok()).toBeTruthy()
 })
 
-test('delete: backup storage not found', async ({ request }) => {
-  const name = 'backup-storage'
+test('create backup storage failures', async ({request}) => {
+    const testCases = [
+        {
+            payload: {},
+            errorText: 'property \"name\" is missing',
+        },
+        {
+            payload: {
+                type: 's3',
+                name: 'backup-storage',
+                bucketName: 'percona-test-backup-storage',
+                region: 'us-east-2',
+                accessKey: 'ssdssd',
+            },
+            errorText: 'property \"secretKey\" is missing',
+        },
+        {
+            payload: {
+                type: 's3',
+                name: 'Backup Name',
+                bucketName: 'percona-test-backup-storage',
+                region: 'us-east-2',
+                accessKey: 'ssdssd',
+                secretKey: 'ssdssdssdssd',
+            },
+            errorText: '\'name\' is not RFC 1035 compatible',
+        },
+        {
+            payload: {
+                type: 's3',
+                name: 'backup',
+                bucketName: 'percona-test-backup-storage',
+                url: 'not-valid-url',
+                region: 'us-east-2',
+                accessKey: 'ssdssd',
+                secretKey: 'ssdssdssdssd',
+            },
+            errorText: '\'url\' is an invalid URL',
+        },
+        {
+            payload: {
+                type: 's3',
+                name: 'missing-region',
+                bucketName: 'invalid',
+                accessKey: 'ssdssd',
+                secretKey: 'ssdssdssdssd',
+            },
+            errorText: 'Region is required',
+        },
+        {
+            payload: {
+                type: 'gcs',
+                name: 'invalid',
+                region: 'us-east-2',
+                bucketName: 'invalid',
+                accessKey: 'ssdssd',
+                secretKey: 'ssdssdssdssd',
+            },
+            errorText: '"/type": value is not one of the allowed values',
+        },
+    ]
 
-  const response = await request.delete(`/v1/backup-storages/${name}`)
+    for (const testCase of testCases) {
+        const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+            data: testCase.payload,
+        })
 
-  expect(response.status()).toBe(404)
+        expect(response.status()).toBe(400)
+        expect((await response.json()).message).toMatch(testCase.errorText)
+    }
 })
 
-test('get: backup storage not found', async ({ request }) => {
-  const name = 'backup-storage'
-  const response = await request.get(`/v1/backup-storages/${name}`)
+test('update backup storage failures', async ({request}) => {
+    const createPayload = {
+        type: 's3',
+        name: 'backup-storage-2',
+        bucketName: 'percona-test-backup-storage',
+        region: 'us-east-2',
+        accessKey: 'sdfsdfs',
+        secretKey: 'lkdfslsldfka',
+    }
+    const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, {
+        data: createPayload,
+    })
 
-  expect(response.status()).toBe(404)
+    expect(response.ok()).toBeTruthy()
+    const created = await response.json()
+
+    const name = created.name
+
+    const testCases = [
+        {
+            payload: {
+                url: '-asldf;asdfk;sadf',
+            },
+            errorText: '\'url\' is an invalid URL',
+        },
+        {
+            payload: {
+                bucket: '-asldf;asdfk;sadf',
+            },
+            errorText: 'request body has an error: doesn\'t match schema #/components/schemas/UpdateBackupStorageParams: property \"bucket\" is unsupported',
+        },
+    ]
+
+    for (const testCase of testCases) {
+        const response = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+            data: testCase.payload,
+        })
+
+        expect((await response.json()).message).toMatch(testCase.errorText)
+        expect(response.status()).toBe(400)
+    }
+
+    const deleted = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+
+    expect(deleted.ok()).toBeTruthy()
+})
+
+test('update: backup storage not found', async ({request}) => {
+    const name = 'some-storage'
+
+    const response = await request.patch(`/v1/namespaces/${testsNs}/backup-storages/${name}`, {
+        data: {
+            bucketName: 's3',
+        },
+    })
+
+    expect(response.status()).toBe(404)
+})
+
+test('delete: backup storage not found', async ({request}) => {
+    const name = 'backup-storage'
+
+    const response = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+
+    expect(response.status()).toBe(404)
+})
+
+test('get: backup storage not found', async ({request}) => {
+    const name = 'backup-storage'
+    const response = await request.get(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+
+    expect(response.status()).toBe(404)
 })

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {expect, test} from '@fixtures'
-import {testsNs} from './helpers'
+import {checkError, testsNs} from './helpers'
 
 test('add/list/get/delete s3 backup storage success', async ({request}) => {
     const payload = {
@@ -33,7 +33,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     })
 
     // create
-    expect(response.ok()).toBeTruthy()
+    await checkError(response)
     const created = await response.json()
 
     const name = created.name
@@ -48,7 +48,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     // list
     const listResponse = await request.get(`/v1/backup-storages`)
 
-    expect(listResponse.ok()).toBeTruthy()
+    await checkError(listResponse)
     const list = await listResponse.json()
 
     expect(list.length).toBeGreaterThan(0)
@@ -56,7 +56,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     // get
     const one = await request.get(`/v1/backup-storages${name}`)
 
-    expect(one.ok()).toBeTruthy()
+    await checkError(one)
     expect((await one.json()).name).toBe(payload.name)
 
     // update
@@ -71,7 +71,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         data: updatePayload,
     })
 
-    expect(updated.ok()).toBeTruthy()
+    await checkError(updated)
     const result = await updated.json()
 
     expect(result.bucketName).toBe(updatePayload.bucketName)
@@ -89,7 +89,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
     // delete
     const deleted = await request.delete(`/v1/backup-storages/${name}`)
 
-    expect(deleted.ok()).toBeTruthy()
+    await checkError(deleted)
 })
 
 test('add/list/get/delete azure backup storage success', async ({request}) => {
@@ -108,7 +108,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
     })
 
     // create
-    expect(response.ok()).toBeTruthy()
+    await checkError(response)
     const created = await response.json()
 
     const name = created.name
@@ -121,7 +121,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
     // list
     const listResponse = await request.get(`/v1/backup-storages`)
 
-    expect(listResponse.ok()).toBeTruthy()
+    await checkError(listResponse)
     const list = await listResponse.json()
 
     expect(list.length).toBeGreaterThan(0)
@@ -129,7 +129,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
     // get
     const one = await request.get(`/v1/backup-storages/${name}`)
 
-    expect(one.ok()).toBeTruthy()
+    await checkError(one)
     expect((await one.json()).name).toBe(payload.name)
 
     // update
@@ -141,7 +141,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
         data: updatePayload,
     })
 
-    expect(updated.ok()).toBeTruthy()
+    await checkError(updated)
     const result = await updated.json()
 
     expect(result.bucketName).toBe(updatePayload.bucketName)
@@ -159,7 +159,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
     // delete
     const deleted = await request.delete(`/v1/backup-storages/${name}`)
 
-    expect(deleted.ok()).toBeTruthy()
+    await checkError(deleted)
 })
 
 test('create backup storage failures', async ({request}) => {
@@ -252,7 +252,7 @@ test('update backup storage failures', async ({request}) => {
         data: createPayload,
     })
 
-    expect(response.ok()).toBeTruthy()
+    await checkError(response)
     const created = await response.json()
 
     const name = created.name
@@ -283,7 +283,7 @@ test('update backup storage failures', async ({request}) => {
 
     const deleted = await request.delete(`/v1/backup-storages/${name}`)
 
-    expect(deleted.ok()).toBeTruthy()
+    await checkError(deleted)
 })
 
 test('update: backup storage not found', async ({request}) => {

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -25,7 +25,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         region: 'us-east-2',
         accessKey: 'sdfs',
         secretKey: 'sdfsdfsd',
-        targetNamespaces: testsNs
+        targetNamespaces: [testsNs]
     }
 
     const response = await request.post(`/v1/backup-storages`, {
@@ -65,7 +65,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         bucketName: 'percona-test-backup-storage1',
         accessKey: 'otherAccessKey',
         secretKey: 'otherSecret',
-        targetNamespaces: testsNs
+        targetNamespaces: [testsNs]
     }
     const updated = await request.patch(`/v1/backup-storages/${name}`, {
         data: updatePayload,
@@ -100,7 +100,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
         bucketName: 'percona-test-backup-storage',
         accessKey: 'sdfs',
         secretKey: 'sdfsdfsd',
-        targetNamespaces: testsNs
+        targetNamespaces: [testsNs]
     }
 
     const response = await request.post(`/v1/backup-storages`, {
@@ -186,7 +186,7 @@ test('create backup storage failures', async ({request}) => {
                 region: 'us-east-2',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: testsNs
+                targetNamespaces: [testsNs]
             },
             errorText: '\'name\' is not RFC 1035 compatible',
         },
@@ -199,7 +199,7 @@ test('create backup storage failures', async ({request}) => {
                 region: 'us-east-2',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: testsNs
+                targetNamespaces: [testsNs]
             },
             errorText: '\'url\' is an invalid URL',
         },
@@ -210,7 +210,7 @@ test('create backup storage failures', async ({request}) => {
                 bucketName: 'invalid',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: testsNs
+                targetNamespaces: [testsNs]
             },
             errorText: 'Region is required',
         },
@@ -222,7 +222,7 @@ test('create backup storage failures', async ({request}) => {
                 bucketName: 'invalid',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: testsNs
+                targetNamespaces: [testsNs]
             },
             errorText: '"/type": value is not one of the allowed values',
         },
@@ -246,7 +246,7 @@ test('update backup storage failures', async ({request}) => {
         region: 'us-east-2',
         accessKey: 'sdfsdfs',
         secretKey: 'lkdfslsldfka',
-        targetNamespaces: testsNs
+        targetNamespaces: [testsNs]
     }
     const response = await request.post(`/v1/backup-storages`, {
         data: createPayload,

--- a/api-tests/tests/database-cluster-backups.spec.ts
+++ b/api-tests/tests/database-cluster-backups.spec.ts
@@ -14,6 +14,7 @@
 // limitations under the License.
 import { expect, test } from '@playwright/test'
 import * as th from './helpers'
+import {testsNs} from "./helpers";
 
 test('create/delete database cluster backups', async ({ request }) => {
   const bsName = th.suffixedName('storage')
@@ -36,13 +37,13 @@ test('create/delete database cluster backups', async ({ request }) => {
     },
   }
 
-  let response = await request.post(`/v1/database-cluster-backups`, {
+  let response = await request.post(`/v1/namespaces/${testsNs}/database-cluster-backups`, {
     data: payload,
   })
 
   expect(response.ok()).toBeTruthy()
 
-  response = await request.get(`/v1/database-cluster-backups/${backupName}`)
+  response = await request.get(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}`)
   const result = await response.json()
 
   expect(result.spec).toMatchObject(payload.spec)
@@ -70,7 +71,7 @@ test('dbcluster not found', async ({ request }) => {
     },
   }
 
-  const response = await request.post(`/v1/database-cluster-backups`, {
+  const response = await request.post(`/v1/namespaces/${testsNs}/database-cluster-backups`, {
     data: payload,
   })
 
@@ -142,7 +143,7 @@ test('list backups', async ({ request, page }) => {
   ]
 
   for (const payload of payloads) {
-    const response = await request.post(`/v1/database-cluster-backups`, {
+    const response = await request.post(`/v1/namespaces/${testsNs}/database-cluster-backups`, {
       data: payload,
     })
 
@@ -150,19 +151,19 @@ test('list backups', async ({ request, page }) => {
   }
 
   await page.waitForTimeout(1000)
-  let response = await request.get(`/v1/database-clusters/${clusterName1}/backups`)
+  let response = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName1}/backups`)
   let result = await response.json()
 
   expect(result.items).toHaveLength(2)
 
-  response = await request.get(`/v1/database-clusters/${clusterName2}/backups`)
+  response = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName2}/backups`)
   result = await response.json()
 
   expect(result.items).toHaveLength(2)
 
   for (const payload of payloads) {
-    await request.delete(`/v1/database-cluster-backups/${payload.metadata.name}`)
-    response = await request.get(`/v1/database-cluster-backups/${payload.metadata.name}`)
+    await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${payload.metadata.name}`)
+    response = await request.get(`/v1/namespaces/${testsNs}/database-cluster-backups/${payload.metadata.name}`)
     expect(response.status()).toBe(404)
   }
 

--- a/api-tests/tests/database-cluster-backups.spec.ts
+++ b/api-tests/tests/database-cluster-backups.spec.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 import { expect, test } from '@playwright/test'
 import * as th from './helpers'
-import {testsNs} from "./helpers";
+import {checkError, testsNs} from "./helpers";
 
 test('create/delete database cluster backups', async ({ request }) => {
   const bsName = th.suffixedName('storage')
@@ -41,7 +41,7 @@ test('create/delete database cluster backups', async ({ request }) => {
     data: payload,
   })
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
 
   response = await request.get(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}`)
   const result = await response.json()
@@ -147,7 +147,7 @@ test('list backups', async ({ request, page }) => {
       data: payload,
     })
 
-    expect(response.ok()).toBeTruthy()
+    await checkError(response)
   }
 
   await page.waitForTimeout(1000)

--- a/api-tests/tests/database-cluster-restores.spec.ts
+++ b/api-tests/tests/database-cluster-restores.spec.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 import { expect, test } from '@playwright/test'
 import * as th from './helpers'
-import {testsNs} from "./helpers";
+import {checkError, testsNs} from "./helpers";
 
 
 test('create/update/delete database cluster restore', async ({ request }) => {
@@ -48,7 +48,7 @@ test('create/update/delete database cluster restore', async ({ request }) => {
     data: payloadRestore,
   })
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const restore = await response.json()
 
   expect(restore.spec).toMatchObject(payloadRestore.spec)
@@ -58,7 +58,7 @@ test('create/update/delete database cluster restore', async ({ request }) => {
   response = await request.put(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`, {
     data: restore,
   })
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const result = await response.json()
 
   expect(result.spec).toMatchObject(restore.spec)
@@ -145,7 +145,7 @@ test('list restores', async ({ request, page }) => {
       data: payload,
     })
 
-    expect(response.ok()).toBeTruthy()
+    await checkError(response)
   }
 
   await page.waitForTimeout(6000)

--- a/api-tests/tests/database-cluster-restores.spec.ts
+++ b/api-tests/tests/database-cluster-restores.spec.ts
@@ -14,6 +14,7 @@
 // limitations under the License.
 import { expect, test } from '@playwright/test'
 import * as th from './helpers'
+import {testsNs} from "./helpers";
 
 
 test('create/update/delete database cluster restore', async ({ request }) => {
@@ -43,7 +44,7 @@ test('create/update/delete database cluster restore', async ({ request }) => {
     },
   }
 
-  let response = await request.post(`/v1/database-cluster-restores`, {
+  let response = await request.post(`/v1/namespaces/${testsNs}/database-cluster-restores`, {
     data: payloadRestore,
   })
 
@@ -54,7 +55,7 @@ test('create/update/delete database cluster restore', async ({ request }) => {
 
   // update restore
   restore.spec.dbClusterName = clName2
-  response = await request.put(`/v1/database-cluster-restores/${restoreName}`, {
+  response = await request.put(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`, {
     data: restore,
   })
   expect(response.ok()).toBeTruthy()
@@ -64,16 +65,16 @@ test('create/update/delete database cluster restore', async ({ request }) => {
 
   // update restore with not existing dbClusterName
   restore.spec.dbClusterName = 'not-existing-cluster'
-  response = await request.put(`/v1/database-cluster-restores/${restoreName}`, {
+  response = await request.put(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`, {
     data: restore,
   })
   expect(response.status()).toBe(400)
   expect(await response.text()).toContain('{"message":"Database cluster not-existing-cluster does not exist"}')
 
   // delete restore
-  await request.delete(`/v1/database-cluster-restores/${restoreName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`)
   // check it couldn't be found anymore
-  response = await request.get(`/v1/database-cluster-restores/${restoreName}`)
+  response = await request.get(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`)
   expect(response.status()).toBe(404)
 
   await th.deleteDBCluster(request, clName)
@@ -140,7 +141,7 @@ test('list restores', async ({ request, page }) => {
   ]
 
   for (const payload of payloads) {
-    const response = await request.post(`/v1/database-cluster-restores`, {
+    const response = await request.post(`/v1/namespaces/${testsNs}/database-cluster-restores`, {
       data: payload,
     })
 
@@ -150,20 +151,20 @@ test('list restores', async ({ request, page }) => {
   await page.waitForTimeout(6000)
 
   // check if the restores are available when being requested via database-clusters/{cluster-name}/restores path
-  let response = await request.get(`/v1/database-clusters/${clName1}/restores`)
+  let response = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clName1}/restores`)
   let result = await response.json()
 
   expect(result.items).toHaveLength(2)
 
-  response = await request.get(`/v1/database-clusters/${clName2}/restores`)
+  response = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clName2}/restores`)
   result = await response.json()
 
   expect(result.items).toHaveLength(1)
 
   // delete the created restores
   for (const payload of payloads) {
-    await request.delete(`/v1/database-cluster-restores/${payload.metadata.name}`)
-    response = await request.get(`/v1/database-cluster-restores/${payload.metadata.name}`)
+    await request.delete(`/v1/namespaces/${testsNs}/database-cluster-restores/${payload.metadata.name}`)
+    response = await request.get(`/v1/namespaces/${testsNs}/database-cluster-restores/${payload.metadata.name}`)
     expect(response.status()).toBe(404)
   }
 
@@ -198,7 +199,7 @@ test('create restore: validation errors', async ({ request, page }) => {
     },
   }
 
-  let response = await request.post(`/v1/database-cluster-restores`, {
+  let response = await request.post(`/v1/namespaces/${testsNs}/database-cluster-restores`, {
     data: payloadRestore,
   })
 
@@ -214,7 +215,7 @@ test('create restore: validation errors', async ({ request, page }) => {
     },
   }
 
-  response = await request.post(`/v1/database-cluster-restores`, {
+  response = await request.post(`/v1/namespaces/${testsNs}/database-cluster-restores`, {
     data: payloadEmptySpec,
   })
   expect(response.status()).toBe(400)

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { expect, test } from '@fixtures'
+import {testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
@@ -85,13 +86,13 @@ test('create db cluster with monitoring config', async ({ request }) => {
     },
   }
 
-  const postReq = await request.post(`/v1/database-clusters`, { data })
+  const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
   expect(postReq.ok()).toBeTruthy()
 
   try {
     await expect(async () => {
-      const pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+      const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
       expect(pgCluster.ok()).toBeTruthy()
       const res = (await pgCluster.json())
@@ -102,7 +103,7 @@ test('create db cluster with monitoring config', async ({ request }) => {
       timeout: 60 * 1000,
     })
   } finally {
-    await request.delete(`/v1/database-clusters/${clusterName}`)
+    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   }
 })
 
@@ -139,7 +140,7 @@ test('update db cluster with a new monitoring config', async ({ request }) => {
     },
   }
 
-  const postReq = await request.post(`/v1/database-clusters`, { data })
+  const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
   expect(postReq.ok()).toBeTruthy()
 
@@ -147,7 +148,7 @@ test('update db cluster with a new monitoring config', async ({ request }) => {
     let res
 
     await expect(async () => {
-      const req = await request.get(`/v1/database-clusters/${clusterName}`)
+      const req = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
       expect(req.ok()).toBeTruthy()
       res = (await req.json())
@@ -164,13 +165,13 @@ test('update db cluster with a new monitoring config', async ({ request }) => {
     putData.metadata = res.metadata
     putData.spec.monitoring.monitoringConfigName = monitoringConfigName2
 
-    const putReq = await request.put(`/v1/database-clusters/${clusterName}`, { data: putData })
+    const putReq = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, { data: putData })
 
     expect(putReq.ok()).toBeTruthy()
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBe(monitoringConfigName2)
   } finally {
-    await request.delete(`/v1/database-clusters/${clusterName}`)
+    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   }
 })
 
@@ -204,7 +205,7 @@ test('update db cluster without monitoring config with a new monitoring config',
     },
   }
 
-  const postReq = await request.post(`/v1/database-clusters`, { data })
+  const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
   expect(postReq.ok()).toBeTruthy()
 
@@ -212,7 +213,7 @@ test('update db cluster without monitoring config with a new monitoring config',
     let res
 
     await expect(async () => {
-      const req = await request.get(`/v1/database-clusters/${clusterName}`)
+      const req = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
       expect(req.ok()).toBeTruthy()
       res = (await req.json())
@@ -229,13 +230,13 @@ test('update db cluster without monitoring config with a new monitoring config',
     putData.metadata = res.metadata;
     (putData.spec as any).monitoring = { monitoringConfigName: monitoringConfigName2 }
 
-    const putReq = await request.put(`/v1/database-clusters/${clusterName}`, { data: putData })
+    const putReq = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, { data: putData })
 
     expect(putReq.ok()).toBeTruthy()
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBe(monitoringConfigName2)
   } finally {
-    await request.delete(`/v1/database-clusters/${clusterName}`)
+    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   }
 })
 
@@ -272,7 +273,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
     },
   }
 
-  const postReq = await request.post(`/v1/database-clusters`, { data })
+  const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
   expect(postReq.ok()).toBeTruthy()
 
@@ -280,7 +281,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
     let res
 
     await expect(async () => {
-      const req = await request.get(`/v1/database-clusters/${clusterName}`)
+      const req = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
       expect(req.ok()).toBeTruthy()
       res = (await req.json())
@@ -295,12 +296,12 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
     putData.metadata = res.metadata;
     (putData.spec.monitoring as any) = {}
 
-    const putReq = await request.put(`/v1/database-clusters/${clusterName}`, { data: putData })
+    const putReq = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, { data: putData })
 
     expect(putReq.ok()).toBeTruthy()
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBeFalsy()
   } finally {
-    await request.delete(`/v1/database-clusters/${clusterName}`)
+    await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   }
 })

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { expect, test } from '@fixtures'
-import {checkError, testsNs} from "@tests/tests/helpers";
+import {checkError, testsNs, testPrefix} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -17,7 +17,7 @@ import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-const testPrefix = `t${(Math.random() + 1).toString(36).substring(10)}`
+export const testPrefix = `t${(Math.random() + 1).toString(36).substring(10)}`
 
 const monitoringConfigName1 = `a${testPrefix}-1`
 const monitoringConfigName2 = `b${testPrefix}-2`

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -29,6 +29,7 @@ test.beforeAll(async ({ request }) => {
     type: 'pmm',
     name: monitoringConfigName1,
     url: 'http://monitoring',
+    targetNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -17,8 +17,6 @@ import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-export const testPrefix = `t${(Math.random() + 1).toString(36).substring(10)}`
-
 const monitoringConfigName1 = `a${testPrefix}-1`
 const monitoringConfigName2 = `b${testPrefix}-2`
 

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { expect, test } from '@fixtures'
-import {testsNs} from "@tests/tests/helpers";
+import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
@@ -37,20 +37,20 @@ test.beforeAll(async ({ request }) => {
   // Monitoring configs
   let res = await request.post('/v1/monitoring-instances', { data: miData })
 
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 
   miData.name = monitoringConfigName2
   res = await request.post('/v1/monitoring-instances', { data: miData })
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 })
 
 test.afterAll(async ({ request }) => {
   let res = await request.delete(`/v1/monitoring-instances/${monitoringConfigName1}`)
 
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 
   res = await request.delete(`/v1/monitoring-instances/${monitoringConfigName2}`)
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 })
 
 test('create db cluster with monitoring config', async ({ request }) => {
@@ -88,13 +88,13 @@ test('create db cluster with monitoring config', async ({ request }) => {
 
   const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
-  expect(postReq.ok()).toBeTruthy()
+  await checkError(postReq)
 
   try {
     await expect(async () => {
       const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-      expect(pgCluster.ok()).toBeTruthy()
+      await checkError(pgCluster)
       const res = (await pgCluster.json())
 
       expect(res?.status?.size).toBeGreaterThanOrEqual(1)
@@ -142,7 +142,7 @@ test('update db cluster with a new monitoring config', async ({ request }) => {
 
   const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
-  expect(postReq.ok()).toBeTruthy()
+  await checkError(postReq)
 
   try {
     let res
@@ -150,7 +150,7 @@ test('update db cluster with a new monitoring config', async ({ request }) => {
     await expect(async () => {
       const req = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-      expect(req.ok()).toBeTruthy()
+      await checkError(req)
       res = (await req.json())
       expect(res?.status?.size).toBeGreaterThanOrEqual(1)
     }).toPass({
@@ -167,7 +167,7 @@ test('update db cluster with a new monitoring config', async ({ request }) => {
 
     const putReq = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, { data: putData })
 
-    expect(putReq.ok()).toBeTruthy()
+    await checkError(putReq)
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBe(monitoringConfigName2)
   } finally {
@@ -207,7 +207,7 @@ test('update db cluster without monitoring config with a new monitoring config',
 
   const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
-  expect(postReq.ok()).toBeTruthy()
+  await checkError(postReq)
 
   try {
     let res
@@ -215,7 +215,7 @@ test('update db cluster without monitoring config with a new monitoring config',
     await expect(async () => {
       const req = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-      expect(req.ok()).toBeTruthy()
+      await checkError(req)
       res = (await req.json())
       expect(res?.status?.size).toBeGreaterThanOrEqual(1)
     }).toPass({
@@ -232,7 +232,7 @@ test('update db cluster without monitoring config with a new monitoring config',
 
     const putReq = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, { data: putData })
 
-    expect(putReq.ok()).toBeTruthy()
+    await checkError(putReq)
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBe(monitoringConfigName2)
   } finally {
@@ -275,7 +275,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
 
   const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
-  expect(postReq.ok()).toBeTruthy()
+  await checkError(postReq)
 
   try {
     let res
@@ -283,7 +283,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
     await expect(async () => {
       const req = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-      expect(req.ok()).toBeTruthy()
+      await checkError(req)
       res = (await req.json())
       expect(res?.status?.size).toBeGreaterThanOrEqual(1)
     }).toPass({
@@ -298,7 +298,7 @@ test('update db cluster monitoring config with an empty monitoring config', asyn
 
     const putReq = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, { data: putData })
 
-    expect(putReq.ok()).toBeTruthy()
+    await checkError(putReq)
     res = (await putReq.json())
     expect(res?.spec?.monitoring?.monitoringConfigName).toBeFalsy()
   } finally {

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -17,7 +17,7 @@ import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-const testPrefix = `${(Math.random() + 1).toString(36).substring(10)}`
+const testPrefix = `t${(Math.random() + 1).toString(36).substring(10)}`
 
 const monitoringConfigName1 = `a${testPrefix}-1`
 const monitoringConfigName2 = `b${testPrefix}-2`

--- a/api-tests/tests/database-engines.spec.ts
+++ b/api-tests/tests/database-engines.spec.ts
@@ -13,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {testsNs} from "@tests/tests/helpers";
+import {checkError, testsNs} from "@tests/tests/helpers";
 
 test('check operators are installed', async ({ request }) => {
   const enginesList = await request.get(`/v1/namespaces/${testsNs}/database-engines`)
 
-  expect(enginesList.ok()).toBeTruthy()
+  await checkError(enginesList)
 
   const engines = (await enginesList.json()).items
 
@@ -37,7 +37,7 @@ test('get/edit database engine versions', async ({ request }) => {
 
   let engineResponse = await request.get(`/v1/namespaces/${testsNs}/database-engines/percona-server-mongodb-operator`)
 
-  expect(engineResponse.ok()).toBeTruthy()
+  await checkError(engineResponse)
 
   const engineData = await engineResponse.json()
   const availableVersions = engineData.status.availableVersions
@@ -54,10 +54,10 @@ test('get/edit database engine versions', async ({ request }) => {
     data: engineData,
   })
 
-  expect(updateResponse.ok()).toBeTruthy()
+  await checkError(updateResponse)
 
   engineResponse = await request.get(`/v1/namespaces/${testsNs}/database-engines/percona-server-mongodb-operator`)
-  expect(engineResponse.ok()).toBeTruthy()
+  await checkError(engineResponse)
 
   expect((await engineResponse.json()).spec.allowedVersions).toEqual(allowedVersions)
 })

--- a/api-tests/tests/database-engines.spec.ts
+++ b/api-tests/tests/database-engines.spec.ts
@@ -13,9 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
+import {testsNs} from "@tests/tests/helpers";
 
 test('check operators are installed', async ({ request }) => {
-  const enginesList = await request.get(`/v1/database-engines`)
+  const enginesList = await request.get(`/v1/namespaces/${testsNs}/database-engines`)
 
   expect(enginesList.ok()).toBeTruthy()
 
@@ -34,7 +35,7 @@ test('check operators are installed', async ({ request }) => {
 
 test('get/edit database engine versions', async ({ request }) => {
 
-  let engineResponse = await request.get(`/v1/database-engines/percona-server-mongodb-operator`)
+  let engineResponse = await request.get(`/v1/namespaces/${testsNs}/database-engines/percona-server-mongodb-operator`)
 
   expect(engineResponse.ok()).toBeTruthy()
 
@@ -49,13 +50,13 @@ test('get/edit database engine versions', async ({ request }) => {
   delete engineData.status
   engineData.spec.allowedVersions = allowedVersions
 
-  const updateResponse = await request.put(`/v1/database-engines/percona-server-mongodb-operator`, {
+  const updateResponse = await request.put(`/v1/namespaces/${testsNs}/database-engines/percona-server-mongodb-operator`, {
     data: engineData,
   })
 
   expect(updateResponse.ok()).toBeTruthy()
 
-  engineResponse = await request.get(`/v1/database-engines/percona-server-mongodb-operator`)
+  engineResponse = await request.get(`/v1/namespaces/${testsNs}/database-engines/percona-server-mongodb-operator`)
   expect(engineResponse.ok()).toBeTruthy()
 
   expect((await engineResponse.json()).spec.allowedVersions).toEqual(allowedVersions)

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -2,10 +2,10 @@ import { expect, test } from '@playwright/test'
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-const testSuffix = () => `t${(Math.random() + 1).toString(36).substring(10)}`
+export const testPrefix = () => `t${(Math.random() + 1).toString(36).substring(10)}`
 
 export const suffixedName = (name) => {
-  return `${name}-${testSuffix()}`
+  return `${name}-${testPrefix()}`
 }
 
 export const checkError = async response => {

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -62,13 +62,13 @@ export const createBackupStorage = async (request, name) => {
     secretKey: 'sdfsdfsd',
   }
 
-  const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, { data: storagePayload })
+  const response = await request.post(`/v1/backup-storages`, { data: storagePayload })
 
   expect(response.ok()).toBeTruthy()
 }
 
 export const deleteBackupStorage = async (request, name) => {
-  const res = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
+  const res = await request.delete(`/v1/backup-storages/${name}`)
 
   expect(res.ok()).toBeTruthy()
 }

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -67,6 +67,7 @@ export const createBackupStorage = async (request, name) => {
     region: 'us-east-2',
     accessKey: 'sdfs',
     secretKey: 'sdfsdfsd',
+    targetNamespaces: [testsNs],
   }
 
   const response = await request.post(`/v1/backup-storages`, { data: storagePayload })

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -8,6 +8,8 @@ export const suffixedName = (name) => {
   return `${name}-${testSuffix()}`
 }
 
+export const testsNs = 'everest'
+
 export const createDBCluster = async (request, name) => {
   const data = {
     apiVersion: 'everest.percona.com/v1alpha1',
@@ -37,13 +39,13 @@ export const createDBCluster = async (request, name) => {
     },
   }
 
-  const postReq = await request.post(`/v1/database-clusters`, { data })
+  const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
   expect(postReq.ok()).toBeTruthy()
 }
 
 export const deleteDBCluster = async (request, name) => {
-  const res = await request.delete(`/v1/database-clusters/${name}`)
+  const res = await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
 
   expect(res.ok()).toBeTruthy()
 }
@@ -60,13 +62,13 @@ export const createBackupStorage = async (request, name) => {
     secretKey: 'sdfsdfsd',
   }
 
-  const response = await request.post('/v1/backup-storages', { data: storagePayload })
+  const response = await request.post(`/v1/namespaces/${testsNs}/backup-storages`, { data: storagePayload })
 
   expect(response.ok()).toBeTruthy()
 }
 
 export const deleteBackupStorage = async (request, name) => {
-  const res = await request.delete(`/v1/backup-storages/${name}`)
+  const res = await request.delete(`/v1/namespaces/${testsNs}/backup-storages/${name}`)
 
   expect(res.ok()).toBeTruthy()
 }
@@ -84,7 +86,7 @@ export const createBackup = async (request,  clusterName, backupName, storageNam
     },
   }
 
-  const responseBackup = await request.post(`/v1/database-cluster-backups`, {
+  const responseBackup = await request.post(`/v1/namespaces/${testsNs}/database-cluster-backups`, {
     data: payloadBackup,
   })
 
@@ -92,13 +94,13 @@ export const createBackup = async (request,  clusterName, backupName, storageNam
 }
 
 export const deleteBackup = async (request, backupName) => {
-  const res = await request.delete(`/v1/database-cluster-backups/${backupName}`)
+  const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}`)
 
   expect(res.ok()).toBeTruthy()
 }
 
 export const deleteRestore = async (request, restoreName) => {
-  const res = await request.delete(`/v1/database-cluster-restores/${restoreName}`)
+  const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`)
 
   expect(res.ok()).toBeTruthy()
 }

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -2,10 +2,10 @@ import { expect, test } from '@playwright/test'
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-export const testPrefix = () => `t${(Math.random() + 1).toString(36).substring(10)}`
+export const testPrefix = `t${(Math.random() + 1).toString(36).substring(10)}`
 
 export const suffixedName = (name) => {
-  return `${name}-${testPrefix()}`
+  return `${name}-${testPrefix}`
 }
 
 export const checkError = async response => {

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -8,6 +8,13 @@ export const suffixedName = (name) => {
   return `${name}-${testSuffix()}`
 }
 
+export const checkError = async response => {
+  if (!response.ok()) {
+    console.log(await response.json())
+  }
+  expect(response.ok()).toBeTruthy()
+}
+
 export const testsNs = 'everest'
 
 export const createDBCluster = async (request, name) => {
@@ -41,13 +48,13 @@ export const createDBCluster = async (request, name) => {
 
   const postReq = await request.post(`/v1/namespaces/${testsNs}/database-clusters`, { data })
 
-  expect(postReq.ok()).toBeTruthy()
+  await checkError(postReq)
 }
 
 export const deleteDBCluster = async (request, name) => {
   const res = await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${name}`)
 
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 }
 
 export const createBackupStorage = async (request, name) => {
@@ -64,13 +71,13 @@ export const createBackupStorage = async (request, name) => {
 
   const response = await request.post(`/v1/backup-storages`, { data: storagePayload })
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
 }
 
 export const deleteBackupStorage = async (request, name) => {
   const res = await request.delete(`/v1/backup-storages/${name}`)
 
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 }
 
 export const createBackup = async (request,  clusterName, backupName, storageName) => {
@@ -90,17 +97,17 @@ export const createBackup = async (request,  clusterName, backupName, storageNam
     data: payloadBackup,
   })
 
-  expect(responseBackup.ok()).toBeTruthy()
+  await checkError(responseBackup)
 }
 
 export const deleteBackup = async (request, backupName) => {
   const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-backups/${backupName}`)
 
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 }
 
 export const deleteRestore = async (request, restoreName) => {
   const res = await request.delete(`/v1/namespaces/${testsNs}/database-cluster-restores/${restoreName}`)
 
-  expect(res.ok()).toBeTruthy()
+  await checkError(res)
 }

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -10,7 +10,7 @@ export const suffixedName = (name) => {
 
 export const checkError = async response => {
   if (!response.ok()) {
-    console.log(await response.json())
+    console.log(`${response.url()}: `, await response.json());
   }
   expect(response.ok()).toBeTruthy()
 }

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-const testSuffix = () => `${(Math.random() + 1).toString(36).substring(10)}`
+const testSuffix = () => `t${(Math.random() + 1).toString(36).substring(10)}`
 
 export const suffixedName = (name) => {
   return `${name}-${testSuffix()}`

--- a/api-tests/tests/kubernetes.spec.ts
+++ b/api-tests/tests/kubernetes.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {checkError} from "@tests/tests/helpers";
+import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
@@ -36,6 +36,7 @@ test('enable/disable cluster-monitoring', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-monit`,
     url: 'http://monitoring',
+    targetNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },

--- a/api-tests/tests/kubernetes.spec.ts
+++ b/api-tests/tests/kubernetes.spec.ts
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
+import {checkError} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
@@ -22,7 +23,7 @@ test('get resource usage', async ({ request }) => {
   const r = await request.get(`/v1/resources`)
   const resources = await r.json()
 
-  expect(r.ok()).toBeTruthy()
+  await checkError(r)
 
   expect(resources).toBeTruthy()
 
@@ -42,7 +43,7 @@ test('enable/disable cluster-monitoring', async ({ request }) => {
 
   const response = await request.post('/v1/monitoring-instances', { data })
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const created = await response.json()
 
   const rEnable = await request.post(`/v1/cluster-monitoring`, {
@@ -52,20 +53,20 @@ test('enable/disable cluster-monitoring', async ({ request }) => {
     },
   })
 
-  expect(rEnable.ok()).toBeTruthy()
+  await checkError(rEnable)
 
   const rDisable = await request.post(`/v1/cluster-monitoring`, {
     data: { enable: false },
   })
 
-  expect(rDisable.ok()).toBeTruthy()
+  await checkError(rDisable)
 })
 
 test('get cluster info', async ({ request }) => {
   const r = await request.get(`/v1/cluster-info`)
   const info = await r.json()
 
-  expect(r.ok()).toBeTruthy()
+  await checkError(r)
 
   expect(info).toBeTruthy()
 

--- a/api-tests/tests/kubernetes.spec.ts
+++ b/api-tests/tests/kubernetes.spec.ts
@@ -17,7 +17,7 @@ import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-const testPrefix = `${(Math.random() + 1).toString(36).substring(10)}`
+const testPrefix = `t${(Math.random() + 1).toString(36).substring(10)}`
 
 test('get resource usage', async ({ request }) => {
   const r = await request.get(`/v1/resources`)

--- a/api-tests/tests/kubernetes.spec.ts
+++ b/api-tests/tests/kubernetes.spec.ts
@@ -31,38 +31,6 @@ test('get resource usage', async ({ request }) => {
   expect(resources?.available).toBeTruthy()
 })
 
-test('enable/disable cluster-monitoring', async ({ request }) => {
-  const data = {
-    type: 'pmm',
-    name: `${testPrefix}-monit`,
-    url: 'http://monitoring',
-    targetNamespaces: [testsNs],
-    pmm: {
-      apiKey: '123',
-    },
-  }
-
-  const response = await request.post('/v1/monitoring-instances', { data })
-
-  await checkError(response)
-  const created = await response.json()
-
-  const rEnable = await request.post(`/v1/cluster-monitoring`, {
-    data: {
-      enable: true,
-      monitoringInstanceName: created.name,
-    },
-  })
-
-  await checkError(rEnable)
-
-  const rDisable = await request.post(`/v1/cluster-monitoring`, {
-    data: { enable: false },
-  })
-
-  await checkError(rDisable)
-})
-
 test('get cluster info', async ({ request }) => {
   const r = await request.get(`/v1/cluster-info`)
   const info = await r.json()

--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -15,6 +15,7 @@
 import http from 'http'
 import { expect, test } from '@fixtures'
 import { APIRequestContext } from '@playwright/test'
+import {testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
@@ -38,6 +39,7 @@ test('create monitoring instance with api key', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-key`,
     url: 'http://monitoring',
+    targetNamespaces: testsNs,
     pmm: {
       apiKey: '123',
     },
@@ -58,6 +60,7 @@ test('create monitoring instance with user/password', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-pass`,
     url: 'http://127.0.0.1:8888',
+    targetNamespaces: testsNs,
     pmm: {
       user: 'admin',
       password: 'admin',
@@ -79,6 +82,7 @@ test('create monitoring instance missing pmm', async ({ request }) => {
     type: 'pmm',
     name: 'monitoring-fail',
     url: 'http://monitoring-instance',
+    targetNamespaces: testsNs,
   }
 
   const response = await request.post('/v1/monitoring-instances', { data })
@@ -91,6 +95,7 @@ test('create monitoring instance missing pmm credentials', async ({ request }) =
     type: 'pmm',
     name: 'monitoring-fail',
     url: 'http://monitoring-instance',
+    targetNamespaces: testsNs,
     pmm: {},
   }
 
@@ -239,6 +244,7 @@ test('update monitoring instances failures', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-fail`,
     url: 'http://monitoring',
+    targetNamespaces: testsNs,
     pmm: {
       apiKey: '123',
     },
@@ -295,6 +301,7 @@ async function createInstances(request: APIRequestContext, namePrefix: string, c
     type: 'pmm',
     name: '',
     url: 'http://monitoring-instance',
+    targetNamespaces: testsNs,
     pmm: {
       apiKey: '123',
     },

--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -39,7 +39,7 @@ test('create monitoring instance with api key', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-key`,
     url: 'http://monitoring',
-    targetNamespaces: testsNs,
+    targetNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },
@@ -60,7 +60,7 @@ test('create monitoring instance with user/password', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-pass`,
     url: 'http://127.0.0.1:8888',
-    targetNamespaces: testsNs,
+    targetNamespaces: [testsNs],
     pmm: {
       user: 'admin',
       password: 'admin',
@@ -82,7 +82,7 @@ test('create monitoring instance missing pmm', async ({ request }) => {
     type: 'pmm',
     name: 'monitoring-fail',
     url: 'http://monitoring-instance',
-    targetNamespaces: testsNs,
+    targetNamespaces: [testsNs],
   }
 
   const response = await request.post('/v1/monitoring-instances', { data })
@@ -95,7 +95,7 @@ test('create monitoring instance missing pmm credentials', async ({ request }) =
     type: 'pmm',
     name: 'monitoring-fail',
     url: 'http://monitoring-instance',
-    targetNamespaces: testsNs,
+    targetNamespaces: [testsNs],
     pmm: {},
   }
 
@@ -244,7 +244,7 @@ test('update monitoring instances failures', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-fail`,
     url: 'http://monitoring',
-    targetNamespaces: testsNs,
+    targetNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },
@@ -301,7 +301,7 @@ async function createInstances(request: APIRequestContext, namePrefix: string, c
     type: 'pmm',
     name: '',
     url: 'http://monitoring-instance',
-    targetNamespaces: testsNs,
+    targetNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },

--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -15,7 +15,7 @@
 import http from 'http'
 import { expect, test } from '@fixtures'
 import { APIRequestContext } from '@playwright/test'
-import {testsNs} from "@tests/tests/helpers";
+import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
@@ -47,7 +47,7 @@ test('create monitoring instance with api key', async ({ request }) => {
 
   const response = await request.post('/v1/monitoring-instances', { data })
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const created = await response.json()
 
   expect(created.name).toBe(data.name)
@@ -69,7 +69,7 @@ test('create monitoring instance with user/password', async ({ request }) => {
 
   const response = await request.post('/v1/monitoring-instances', { data })
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const created = await response.json()
 
   expect(created.name).toBe(data.name)
@@ -111,7 +111,7 @@ test('list monitoring instances', async ({ request }) => {
 
   const response = await request.get('/v1/monitoring-instances')
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const list = await response.json()
 
   expect(list.filter((i) => i.name.startsWith(`${namePrefix}${testPrefix}`)).length).toBe(3)
@@ -124,7 +124,7 @@ test('get monitoring instance', async ({ request }) => {
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const i = await response.json()
 
   expect(i.name).toBe(name)
@@ -137,16 +137,16 @@ test('delete monitoring instance', async ({ request }) => {
 
   let response = await request.get('/v1/monitoring-instances')
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   let list = await response.json()
 
   expect(list.filter((i) => i.name.startsWith(`${namePrefix}${testPrefix}`)).length).toBe(3)
 
   response = await request.delete(`/v1/monitoring-instances/${name}`)
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
 
   response = await request.get('/v1/monitoring-instances')
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   list = await response.json()
 
   expect(list.filter((i) => i.name.startsWith(`${namePrefix}${testPrefix}`)).length).toBe(2)
@@ -158,13 +158,13 @@ test('patch monitoring instance', async ({ request }) => {
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const created = await response.json()
 
   const patchData = { url: 'http://monitoring' }
   const updated = await request.patch(`/v1/monitoring-instances/${name}`, { data: patchData })
 
-  expect(updated.ok()).toBeTruthy()
+  await checkError(updated)
   const getJson = await updated.json()
 
   expect(getJson.url).toBe(patchData.url)
@@ -177,7 +177,7 @@ test('patch monitoring instance secret key changes', async ({ request }) => {
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const created = await response.json()
 
   const patchData = {
@@ -188,7 +188,7 @@ test('patch monitoring instance secret key changes', async ({ request }) => {
   }
   const updated = await request.patch(`/v1/monitoring-instances/${name}`, { data: patchData })
 
-  expect(updated.ok()).toBeTruthy()
+  await checkError(updated)
   const getJson = await updated.json()
 
   expect(getJson.url).toBe(patchData.url)
@@ -200,7 +200,7 @@ test('patch monitoring instance type updates properly', async ({ request }) => {
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
 
   const patchData = {
     type: 'pmm',
@@ -210,7 +210,7 @@ test('patch monitoring instance type updates properly', async ({ request }) => {
   }
   const updated = await request.patch(`/v1/monitoring-instances/${name}`, { data: patchData })
 
-  expect(updated.ok()).toBeTruthy()
+  await checkError(updated)
   const getJson = await updated.json()
 })
 
@@ -220,7 +220,7 @@ test('patch monitoring instance type fails on missing key', async ({ request }) 
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
 
   const patchData = {
     type: 'pmm',
@@ -251,7 +251,7 @@ test('update monitoring instances failures', async ({ request }) => {
   }
   const response = await request.post('/v1/monitoring-instances', { data })
 
-  expect(response.ok()).toBeTruthy()
+  await checkError(response)
   const created = await response.json()
 
   const name = created.name
@@ -314,7 +314,7 @@ async function createInstances(request: APIRequestContext, namePrefix: string, c
     res.push(data.name)
     const response = await request.post('/v1/monitoring-instances', { data })
 
-    expect(response.ok()).toBeTruthy()
+    await checkError(response)
   }
 
   return res

--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -19,7 +19,7 @@ import {checkError, testsNs} from "@tests/tests/helpers";
 
 // testPrefix is used to differentiate between several workers
 // running this test to avoid conflicts in instance names
-const testPrefix = `${(Math.random() + 1).toString(36).substring(10)}`
+const testPrefix = `t${(Math.random() + 1).toString(36).substring(10)}`
 
 test.afterEach(async ({ request }, testInfo) => {
   const result = await request.get('/v1/monitoring-instances')

--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -153,7 +153,7 @@ test('delete monitoring instance', async ({ request }) => {
 })
 
 test('patch monitoring instance', async ({ request }) => {
-  const names = await createInstances(request, 'patch-monitoring-')
+  const names = await createInstances(request, 'patch-monit-')
   const name = names[1]
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
@@ -172,7 +172,7 @@ test('patch monitoring instance', async ({ request }) => {
 })
 
 test('patch monitoring instance secret key changes', async ({ request }) => {
-  const names = await createInstances(request, 'patch-monitoring-')
+  const names = await createInstances(request, 'patch-monit-')
   const name = names[1]
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
@@ -195,7 +195,7 @@ test('patch monitoring instance secret key changes', async ({ request }) => {
 })
 
 test('patch monitoring instance type updates properly', async ({ request }) => {
-  const names = await createInstances(request, 'patch-monitoring-')
+  const names = await createInstances(request, 'patch-monit-')
   const name = names[1]
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)
@@ -215,7 +215,7 @@ test('patch monitoring instance type updates properly', async ({ request }) => {
 })
 
 test('patch monitoring instance type fails on missing key', async ({ request }) => {
-  const names = await createInstances(request, 'patch-monitoring-')
+  const names = await createInstances(request, 'patch-monit-')
   const name = names[1]
 
   const response = await request.get(`/v1/monitoring-instances/${name}`)

--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -131,7 +131,7 @@ test('get monitoring instance', async ({ request }) => {
 })
 
 test('delete monitoring instance', async ({ request }) => {
-  const namePrefix = 'delete-'
+  const namePrefix = 'del-'
   const names = await createInstances(request, namePrefix)
   const name = names[1]
 

--- a/api-tests/tests/pg-clusters.spec.ts
+++ b/api-tests/tests/pg-clusters.spec.ts
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
+import {testsNs} from "@tests/tests/helpers";
 
 let recommendedVersion
 
 test.beforeAll(async ({ request }) => {
-  const engineResponse = await request.get(`/v1/database-engines/percona-postgresql-operator`)
+  const engineResponse = await request.get(`/v1/namespaces/${testsNs}/database-engines/percona-postgresql-operator`)
   const availableVersions = (await engineResponse.json()).status.availableVersions.engine
 
   for (const k in availableVersions) {
@@ -60,13 +61,13 @@ test('create/edit/delete single node pg cluster', async ({ request, page }) => {
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: pgPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(1000)
 
-    const pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(pgCluster.ok()).toBeTruthy()
 
@@ -93,21 +94,21 @@ test('create/edit/delete single node pg cluster', async ({ request, page }) => {
 
   // Update PG cluster
 
-  const updatedPGCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPGCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: pgPayload,
   })
 
   expect(updatedPGCluster.ok()).toBeTruthy()
 
-  let pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  let pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(pgCluster.ok()).toBeTruthy()
 
   expect((await updatedPGCluster.json()).spec.clusterSize).toBe(pgPayload.spec.clusterSize)
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   expect(pgCluster.status()).toBe(404)
 })
 
@@ -142,13 +143,13 @@ test('expose pg cluster after creation', async ({ request, page }) => {
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: pgPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(1000)
 
-    const pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(pgCluster.ok()).toBeTruthy()
 
@@ -171,21 +172,21 @@ test('expose pg cluster after creation', async ({ request, page }) => {
 
   // Update PG cluster
 
-  const updatedPGCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPGCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: pgPayload,
   })
 
   expect(updatedPGCluster.ok()).toBeTruthy()
 
-  let pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  let pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(pgCluster.ok()).toBeTruthy()
 
   expect((await updatedPGCluster.json()).spec.proxy.expose.type).toBe('external')
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   expect(pgCluster.status()).toBe(404)
 })
 
@@ -220,13 +221,13 @@ test('expose pg cluster on EKS to the public internet and scale up', async ({ re
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: pgPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(2000)
 
-    const pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(pgCluster.ok()).toBeTruthy()
 
@@ -249,16 +250,16 @@ test('expose pg cluster on EKS to the public internet and scale up', async ({ re
 
   // Update PG cluster
 
-  const updatedPGCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPGCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: pgPayload,
   })
 
   expect(updatedPGCluster.ok()).toBeTruthy()
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   await page.waitForTimeout(1000)
 
-  const pgCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(pgCluster.status()).toBe(404)
 })

--- a/api-tests/tests/pg-clusters.spec.ts
+++ b/api-tests/tests/pg-clusters.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {testsNs} from "@tests/tests/helpers";
+import {checkError, testsNs} from "@tests/tests/helpers";
 
 let recommendedVersion
 
@@ -69,7 +69,7 @@ test('create/edit/delete single node pg cluster', async ({ request, page }) => {
 
     const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(pgCluster.ok()).toBeTruthy()
+    await checkError(pgCluster)
 
     const result = (await pgCluster.json())
 
@@ -98,11 +98,11 @@ test('create/edit/delete single node pg cluster', async ({ request, page }) => {
     data: pgPayload,
   })
 
-  expect(updatedPGCluster.ok()).toBeTruthy()
+  await checkError(updatedPGCluster)
 
   let pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(pgCluster.ok()).toBeTruthy()
+  await checkError(pgCluster)
 
   expect((await updatedPGCluster.json()).spec.clusterSize).toBe(pgPayload.spec.clusterSize)
 
@@ -151,7 +151,7 @@ test('expose pg cluster after creation', async ({ request, page }) => {
 
     const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(pgCluster.ok()).toBeTruthy()
+    await checkError(pgCluster)
 
     const result = (await pgCluster.json())
 
@@ -176,11 +176,11 @@ test('expose pg cluster after creation', async ({ request, page }) => {
     data: pgPayload,
   })
 
-  expect(updatedPGCluster.ok()).toBeTruthy()
+  await checkError(updatedPGCluster)
 
   let pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(pgCluster.ok()).toBeTruthy()
+  await checkError(pgCluster)
 
   expect((await updatedPGCluster.json()).spec.proxy.expose.type).toBe('external')
 
@@ -229,7 +229,7 @@ test('expose pg cluster on EKS to the public internet and scale up', async ({ re
 
     const pgCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(pgCluster.ok()).toBeTruthy()
+    await checkError(pgCluster)
 
     const result = (await pgCluster.json())
 
@@ -254,7 +254,7 @@ test('expose pg cluster on EKS to the public internet and scale up', async ({ re
     data: pgPayload,
   })
 
-  expect(updatedPGCluster.ok()).toBeTruthy()
+  await checkError(updatedPGCluster)
 
   await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   await page.waitForTimeout(1000)

--- a/api-tests/tests/psmdb-clusters.spec.ts
+++ b/api-tests/tests/psmdb-clusters.spec.ts
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
+import {testsNs} from "@tests/tests/helpers";
 
 
 test.beforeAll(async ({ request }) => {
-  const engineResponse = await request.get(`/v1/database-engines/percona-server-mongodb-operator`)
+  const engineResponse = await request.get(`/v1/namespaces/${testsNs}/database-engines/percona-server-mongodb-operator`)
   const availableVersions = (await engineResponse.json()).status.availableVersions.engine
 })
 
@@ -50,13 +51,13 @@ test('create/edit/delete single node psmdb cluster', async ({ request, page }) =
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: psmdbPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(1000)
 
-    const psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(psmdbCluster.ok()).toBeTruthy()
 
@@ -74,7 +75,7 @@ test('create/edit/delete single node psmdb cluster', async ({ request, page }) =
 
   psmdbPayload.spec.engine.config = 'operationProfiling:\nmode: slowOp'
 
-  let psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  let psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(psmdbCluster.ok()).toBeTruthy()
   const result = (await psmdbCluster.json())
@@ -84,21 +85,21 @@ test('create/edit/delete single node psmdb cluster', async ({ request, page }) =
 
   // Update PSMDB cluster
 
-  const updatedPSMDBCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPSMDBCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: psmdbPayload,
   })
 
   expect(updatedPSMDBCluster.ok()).toBeTruthy()
 
-  psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(psmdbCluster.ok()).toBeTruthy()
 
   expect((await updatedPSMDBCluster.json()).spec.engine.config).toBe(psmdbPayload.spec.engine.config)
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   expect(psmdbCluster.status()).toBe(404)
 })
 
@@ -132,14 +133,14 @@ test('expose psmdb cluster after creation', async ({ request, page }) => {
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: psmdbPayload,
   })
 
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(1000)
 
-    const psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(psmdbCluster.ok()).toBeTruthy()
 
@@ -156,7 +157,7 @@ test('expose psmdb cluster after creation', async ({ request, page }) => {
     break
   }
 
-  let psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  let psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(psmdbCluster.ok()).toBeTruthy()
   const result = (await psmdbCluster.json())
@@ -167,22 +168,22 @@ test('expose psmdb cluster after creation', async ({ request, page }) => {
 
   // Update PSMDB cluster
 
-  const updatedPSMDBCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPSMDBCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: psmdbPayload,
   })
 
   expect(updatedPSMDBCluster.ok()).toBeTruthy()
   await page.waitForTimeout(1000)
 
-  psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(psmdbCluster.ok()).toBeTruthy()
 
   expect((await updatedPSMDBCluster.json()).spec.proxy.expose.type).toBe('external')
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   expect(psmdbCluster.status()).toBe(404)
 })
 
@@ -216,13 +217,13 @@ test('expose psmdb cluster on EKS to the public internet and scale up', async ({
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: psmdbPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(2000)
 
-    const psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(psmdbCluster.ok()).toBeTruthy()
 
@@ -239,7 +240,7 @@ test('expose psmdb cluster on EKS to the public internet and scale up', async ({
   }
 
   psmdbPayload.spec.engine.replicas = 5
-  let psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  let psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(psmdbCluster.ok()).toBeTruthy()
   const result = (await psmdbCluster.json())
@@ -249,19 +250,19 @@ test('expose psmdb cluster on EKS to the public internet and scale up', async ({
 
   // Update PSMDB cluster
 
-  const updatedPSMDBCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPSMDBCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: psmdbPayload,
   })
 
   expect(updatedPSMDBCluster.ok()).toBeTruthy()
 
-  psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(psmdbCluster.ok()).toBeTruthy()
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   await page.waitForTimeout(1000)
 
-  psmdbCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   expect(psmdbCluster.status()).toBe(404)
 })

--- a/api-tests/tests/psmdb-clusters.spec.ts
+++ b/api-tests/tests/psmdb-clusters.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {testsNs} from "@tests/tests/helpers";
+import {checkError, testsNs} from "@tests/tests/helpers";
 
 
 test.beforeAll(async ({ request }) => {
@@ -59,7 +59,7 @@ test('create/edit/delete single node psmdb cluster', async ({ request, page }) =
 
     const psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(psmdbCluster.ok()).toBeTruthy()
+    await checkError(psmdbCluster)
 
     const result = (await psmdbCluster.json())
 
@@ -77,7 +77,7 @@ test('create/edit/delete single node psmdb cluster', async ({ request, page }) =
 
   let psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(psmdbCluster.ok()).toBeTruthy()
+  await checkError(psmdbCluster)
   const result = (await psmdbCluster.json())
 
   psmdbPayload.spec = result.spec
@@ -89,11 +89,11 @@ test('create/edit/delete single node psmdb cluster', async ({ request, page }) =
     data: psmdbPayload,
   })
 
-  expect(updatedPSMDBCluster.ok()).toBeTruthy()
+  await checkError(updatedPSMDBCluster)
 
   psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(psmdbCluster.ok()).toBeTruthy()
+  await checkError(psmdbCluster)
 
   expect((await updatedPSMDBCluster.json()).spec.engine.config).toBe(psmdbPayload.spec.engine.config)
 
@@ -142,7 +142,7 @@ test('expose psmdb cluster after creation', async ({ request, page }) => {
 
     const psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(psmdbCluster.ok()).toBeTruthy()
+    await checkError(psmdbCluster)
 
     const result = (await psmdbCluster.json())
 
@@ -159,7 +159,7 @@ test('expose psmdb cluster after creation', async ({ request, page }) => {
 
   let psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(psmdbCluster.ok()).toBeTruthy()
+  await checkError(psmdbCluster)
   const result = (await psmdbCluster.json())
 
   psmdbPayload.spec = result.spec
@@ -172,12 +172,12 @@ test('expose psmdb cluster after creation', async ({ request, page }) => {
     data: psmdbPayload,
   })
 
-  expect(updatedPSMDBCluster.ok()).toBeTruthy()
+  await checkError(updatedPSMDBCluster)
   await page.waitForTimeout(1000)
 
   psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(psmdbCluster.ok()).toBeTruthy()
+  await checkError(psmdbCluster)
 
   expect((await updatedPSMDBCluster.json()).spec.proxy.expose.type).toBe('external')
 
@@ -225,7 +225,7 @@ test('expose psmdb cluster on EKS to the public internet and scale up', async ({
 
     const psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(psmdbCluster.ok()).toBeTruthy()
+    await checkError(psmdbCluster)
 
     const result = (await psmdbCluster.json())
 
@@ -242,7 +242,7 @@ test('expose psmdb cluster on EKS to the public internet and scale up', async ({
   psmdbPayload.spec.engine.replicas = 5
   let psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(psmdbCluster.ok()).toBeTruthy()
+  await checkError(psmdbCluster)
   const result = (await psmdbCluster.json())
 
   psmdbPayload.spec = result.spec
@@ -254,11 +254,11 @@ test('expose psmdb cluster on EKS to the public internet and scale up', async ({
     data: psmdbPayload,
   })
 
-  expect(updatedPSMDBCluster.ok()).toBeTruthy()
+  await checkError(updatedPSMDBCluster)
 
   psmdbCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(psmdbCluster.ok()).toBeTruthy()
+  await checkError(psmdbCluster)
 
   await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   await page.waitForTimeout(1000)

--- a/api-tests/tests/pxc-clusters.spec.ts
+++ b/api-tests/tests/pxc-clusters.spec.ts
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
+import {testsNs} from "@tests/tests/helpers";
 
 let recommendedVersion
 
 test.beforeAll(async ({ request }) => {
-  const engineResponse = await request.get(`/v1/database-engines/percona-xtradb-cluster-operator`)
+  const engineResponse = await request.get(`/v1/namespaces/${testsNs}/database-engines/percona-xtradb-cluster-operator`)
   const availableVersions = (await engineResponse.json()).status.availableVersions.engine
 
   for (const k in availableVersions) {
@@ -64,13 +65,13 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: pxcPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(1000)
 
-    const pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(pxcCluster.ok()).toBeTruthy()
 
@@ -96,7 +97,7 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
   pxcPayload.spec.engine.config = '[mysqld]\nwsrep_provider_options="debug=1;gcache.size=1G"\n'
 
   // check that the /pitr endpoint returns OK and an empty object since pitr is not enabled
-  const pitrResponse = await request.get(`/v1/database-clusters/${clusterName}/pitr`)
+  const pitrResponse = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}/pitr`)
   expect(pitrResponse.ok()).toBeTruthy()
   const pitrInfo = (await pitrResponse.json())
   expect(pitrInfo.latestBackupName).toBe(undefined)
@@ -105,21 +106,21 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
 
   // Update PXC cluster
 
-  const updatedPXCCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPXCCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: pxcPayload,
   })
 
   expect(updatedPXCCluster.ok()).toBeTruthy()
 
-  let pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  let pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(pxcCluster.ok()).toBeTruthy()
 
   expect((await updatedPXCCluster.json()).spec.databaseConfig).toBe(pxcPayload.spec.databaseConfig)
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   expect(pxcCluster.status()).toBe(404)
 })
 
@@ -154,13 +155,13 @@ test('expose pxc cluster after creation', async ({ request, page }) => {
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: pxcPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(1000)
 
-    const pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(pxcCluster.ok()).toBeTruthy()
 
@@ -183,21 +184,21 @@ test('expose pxc cluster after creation', async ({ request, page }) => {
 
   // Update PXC cluster
 
-  const updatedPXCCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPXCCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: pxcPayload,
   })
 
   expect(updatedPXCCluster.ok()).toBeTruthy()
 
-  let pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  let pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(pxcCluster.ok()).toBeTruthy()
 
   expect((await updatedPXCCluster.json()).spec.proxy.expose.type).toBe('external')
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   expect(pxcCluster.status()).toBe(404)
 })
 
@@ -233,13 +234,13 @@ test('expose pxc cluster on EKS to the public internet and scale up', async ({ r
     },
   }
 
-  await request.post(`/v1/database-clusters`, {
+  await request.post(`/v1/namespaces/${testsNs}/database-clusters`, {
     data: pxcPayload,
   })
   for (let i = 0; i < 15; i++) {
     await page.waitForTimeout(10000)
 
-    const pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+    const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
     expect(pxcCluster.ok()).toBeTruthy()
 
@@ -262,16 +263,16 @@ test('expose pxc cluster on EKS to the public internet and scale up', async ({ r
 
   // Update PXC cluster
 
-  const updatedPXCCluster = await request.put(`/v1/database-clusters/${clusterName}`, {
+  const updatedPXCCluster = await request.put(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`, {
     data: pxcPayload,
   })
 
   expect(updatedPXCCluster.ok()).toBeTruthy()
 
-  await request.delete(`/v1/database-clusters/${clusterName}`)
+  await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   await page.waitForTimeout(1000)
 
-  const pxcCluster = await request.get(`/v1/database-clusters/${clusterName}`)
+  const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
   expect(pxcCluster.status()).toBe(404)
 })

--- a/api-tests/tests/pxc-clusters.spec.ts
+++ b/api-tests/tests/pxc-clusters.spec.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { test, expect } from '@fixtures'
-import {testsNs} from "@tests/tests/helpers";
+import {checkError, testsNs} from "@tests/tests/helpers";
 
 let recommendedVersion
 
@@ -73,7 +73,7 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
 
     const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(pxcCluster.ok()).toBeTruthy()
+    await checkError(pxcCluster)
 
     const result = (await pxcCluster.json())
 
@@ -98,7 +98,7 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
 
   // check that the /pitr endpoint returns OK and an empty object since pitr is not enabled
   const pitrResponse = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}/pitr`)
-  expect(pitrResponse.ok()).toBeTruthy()
+  await checkError(pitrResponse)
   const pitrInfo = (await pitrResponse.json())
   expect(pitrInfo.latestBackupName).toBe(undefined)
   expect(pitrInfo.earliestDate).toBe(undefined)
@@ -110,11 +110,11 @@ test('create/edit/delete pxc single node cluster', async ({ request, page }) => 
     data: pxcPayload,
   })
 
-  expect(updatedPXCCluster.ok()).toBeTruthy()
+  await checkError(updatedPXCCluster)
 
   let pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(pxcCluster.ok()).toBeTruthy()
+  await checkError(pxcCluster)
 
   expect((await updatedPXCCluster.json()).spec.databaseConfig).toBe(pxcPayload.spec.databaseConfig)
 
@@ -163,7 +163,7 @@ test('expose pxc cluster after creation', async ({ request, page }) => {
 
     const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(pxcCluster.ok()).toBeTruthy()
+    await checkError(pxcCluster)
 
     const result = (await pxcCluster.json())
 
@@ -188,11 +188,11 @@ test('expose pxc cluster after creation', async ({ request, page }) => {
     data: pxcPayload,
   })
 
-  expect(updatedPXCCluster.ok()).toBeTruthy()
+  await checkError(updatedPXCCluster)
 
   let pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-  expect(pxcCluster.ok()).toBeTruthy()
+  await checkError(pxcCluster)
 
   expect((await updatedPXCCluster.json()).spec.proxy.expose.type).toBe('external')
 
@@ -242,7 +242,7 @@ test('expose pxc cluster on EKS to the public internet and scale up', async ({ r
 
     const pxcCluster = await request.get(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
 
-    expect(pxcCluster.ok()).toBeTruthy()
+    await checkError(pxcCluster)
 
     const result = (await pxcCluster.json())
 
@@ -267,7 +267,7 @@ test('expose pxc cluster on EKS to the public internet and scale up', async ({ r
     data: pxcPayload,
   })
 
-  expect(updatedPXCCluster.ok()).toBeTruthy()
+  await checkError(updatedPXCCluster)
 
   await request.delete(`/v1/namespaces/${testsNs}/database-clusters/${clusterName}`)
   await page.waitForTimeout(1000)

--- a/api-tests/tests/version.spec.ts
+++ b/api-tests/tests/version.spec.ts
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { expect, test } from '@fixtures'
+import {checkError} from "@tests/tests/helpers";
 
 test('version endpoint', async ({ request, cli }) => {
   const version = await request.get('/v1/version')
 
-  expect(version.ok()).toBeTruthy()
+  await checkError(version)
 
   const versionJSON = await version.json()
 

--- a/api/everest_test.go
+++ b/api/everest_test.go
@@ -31,25 +31,25 @@ func TestBuildProxiedUrl(t *testing.T) {
 
 	cases := []tCase{
 		{
-			url:      "/v1/database-clusters",
+			url:      "/v1/namespaces/some-ns/database-clusters",
 			kind:     "databaseclusters",
 			name:     "",
 			expected: "/apis/everest.percona.com/v1alpha1/namespaces/everest/databaseclusters",
 		},
 		{
-			url:      "/v1/database-clusters/snake_case_name",
+			url:      "/v1/namespaces/some-ns/database-clusters/snake_case_name",
 			kind:     "databaseclusters",
 			name:     "snake_case_name",
 			expected: "/apis/everest.percona.com/v1alpha1/namespaces/everest/databaseclusters/snake_case_name",
 		},
 		{
-			url:      "/v1/database-clusters/kebab-case-name",
+			url:      "/v1/namespaces/some-ns/database-clusters/kebab-case-name",
 			kind:     "databaseclusters",
 			name:     "kebab-case-name",
 			expected: "/apis/everest.percona.com/v1alpha1/namespaces/everest/databaseclusters/kebab-case-name",
 		},
 		{
-			url:      "/v1/database-cluster-restores/kebab-case-name",
+			url:      "/v1/namespaces/some-ns/database-cluster-restores/kebab-case-name",
 			kind:     "databaseclusterrestores",
 			name:     "kebab-case-name",
 			expected: "/apis/everest.percona.com/v1alpha1/namespaces/everest/databaseclusterrestores/kebab-case-name",

--- a/api/monitoring_instance.go
+++ b/api/monitoring_instance.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// MonitoringNamespace is the namespace where monitoring configs are created.
-	MonitoringNamespace = "percona-everest-monitoring"
+	MonitoringNamespace = "everest-monitoring"
 )
 
 // CreateMonitoringInstance creates a new monitoring instance.


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Update CI**
---
**Problem:**
EVEREST-107

- Update tests to use multinamespace. 
- Remove `monitroring enable`
- Log details of failures

[EVEREST-107]: https://perconadev.atlassian.net/browse/EVEREST-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ