### PR TITLE
EVEREST-832 Fix access to namespaces

### DIFF
--- a/api/database_cluster_backup.go
+++ b/api/database_cluster_backup.go
@@ -59,7 +59,7 @@ func (e *EverestServer) CreateDatabaseClusterBackup(ctx echo.Context, namespace 
 		})
 	}
 	// TODO: Improve returns status code in EVEREST-616
-	if err := validateDatabaseClusterBackup(ctx.Request().Context(), namespace, dbb, e.kubeClient); err != nil {
+	if err := e.validateDatabaseClusterBackup(ctx.Request().Context(), namespace, dbb); err != nil {
 		e.l.Error(err)
 		return ctx.JSON(http.StatusBadRequest, Error{Message: pointer.ToString(err.Error())})
 	}

--- a/api/validation.go
+++ b/api/validation.go
@@ -613,18 +613,12 @@ func (e *EverestServer) validateBackupStoragesAccess(ctx context.Context, namesp
 		return nil, fmt.Errorf("could not validate backup storage %s", name)
 	}
 
-	found := false
 	for _, ns := range bs.Spec.TargetNamespaces {
 		if ns == namespace {
-			found = true
-			break
+			return bs, nil
 		}
 	}
-	if !found {
-		return nil, fmt.Errorf("backup storage %s is not allowed for namespace %s", name, namespace)
-	}
-
-	return bs, nil
+	return nil, fmt.Errorf("backup storage %s is not allowed for namespace %s", name, namespace)
 }
 
 func (e *EverestServer) validateMonitoringConfigAccess(ctx context.Context, namespace, name string) (*everestv1alpha1.MonitoringConfig, error) {

--- a/api/validation.go
+++ b/api/validation.go
@@ -636,18 +636,12 @@ func (e *EverestServer) validateMonitoringConfigAccess(ctx context.Context, name
 		return nil, fmt.Errorf("failed getting monitoring config %s", name)
 	}
 
-	found := false
 	for _, ns := range mc.Spec.TargetNamespaces {
 		if ns == namespace {
-			found = true
-			break
+			return mc, nil
 		}
 	}
-	if !found {
-		return nil, fmt.Errorf("monitoring config %s is not allowed for namespace %s", name, namespace)
-	}
-
-	return mc, nil
+	return nil, fmt.Errorf("monitoring config %s is not allowed for namespace %s", name, namespace)
 }
 
 func validateVersion(version *string, engine *everestv1alpha1.DatabaseEngine) error {


### PR DESCRIPTION
[![EVEREST-832](https://badgen.net/badge/JIRA/EVEREST-832/green)](https://jira.percona.com/browse/EVEREST-832) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Fix access to namespaces**
---
**Problem:**
EVEREST-832

DBCs and DBBs had access to all BackupStorages and MonitoringConfigs regardless of the namespace.

**Cause:**
We weren't validating if a given BackupStorage or MonitoringConfig was allowed in the DBC's namespace.

**Solution:**
Validate if a given BackupStorage or MonitoringConfig is allowed in the DBC's namespace.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

[EVEREST-832]: https://perconadev.atlassian.net/browse/EVEREST-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ