### PR TITLE
EVEREST-107 Rename TargetNamespaces to AllowedNamespaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
             --operator.postgresql \
             --operator.xtradb-cluster \
             --skip-wizard \
-            --namespace everest
+            --namespaces everest
 
           # API_TOKEN is used later by "make test"
           echo "API_TOKEN=$(./bin/everest token reset --json | jq .token -r)" >> $GITHUB_ENV

--- a/api-tests/tests/backup-storages.spec.ts
+++ b/api-tests/tests/backup-storages.spec.ts
@@ -25,7 +25,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         region: 'us-east-2',
         accessKey: 'sdfs',
         secretKey: 'sdfsdfsd',
-        targetNamespaces: [testsNs]
+        allowedNamespaces: [testsNs]
     }
 
     const response = await request.post(`/v1/backup-storages`, {
@@ -65,7 +65,7 @@ test('add/list/get/delete s3 backup storage success', async ({request}) => {
         bucketName: 'percona-test-backup-storage1',
         accessKey: 'otherAccessKey',
         secretKey: 'otherSecret',
-        targetNamespaces: [testsNs]
+        allowedNamespaces: [testsNs]
     }
     const updated = await request.patch(`/v1/backup-storages/${name}`, {
         data: updatePayload,
@@ -100,7 +100,7 @@ test('add/list/get/delete azure backup storage success', async ({request}) => {
         bucketName: 'percona-test-backup-storage',
         accessKey: 'sdfs',
         secretKey: 'sdfsdfsd',
-        targetNamespaces: [testsNs]
+        allowedNamespaces: [testsNs]
     }
 
     const response = await request.post(`/v1/backup-storages`, {
@@ -186,7 +186,7 @@ test('create backup storage failures', async ({request}) => {
                 region: 'us-east-2',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: [testsNs]
+                allowedNamespaces: [testsNs]
             },
             errorText: '\'name\' is not RFC 1035 compatible',
         },
@@ -199,7 +199,7 @@ test('create backup storage failures', async ({request}) => {
                 region: 'us-east-2',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: [testsNs]
+                allowedNamespaces: [testsNs]
             },
             errorText: '\'url\' is an invalid URL',
         },
@@ -210,7 +210,7 @@ test('create backup storage failures', async ({request}) => {
                 bucketName: 'invalid',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: [testsNs]
+                allowedNamespaces: [testsNs]
             },
             errorText: 'Region is required',
         },
@@ -222,7 +222,7 @@ test('create backup storage failures', async ({request}) => {
                 bucketName: 'invalid',
                 accessKey: 'ssdssd',
                 secretKey: 'ssdssdssdssd',
-                targetNamespaces: [testsNs]
+                allowedNamespaces: [testsNs]
             },
             errorText: '"/type": value is not one of the allowed values',
         },
@@ -246,7 +246,7 @@ test('update backup storage failures', async ({request}) => {
         region: 'us-east-2',
         accessKey: 'sdfsdfs',
         secretKey: 'lkdfslsldfka',
-        targetNamespaces: [testsNs]
+        allowedNamespaces: [testsNs]
     }
     const response = await request.post(`/v1/backup-storages`, {
         data: createPayload,

--- a/api-tests/tests/database-cluster.spec.ts
+++ b/api-tests/tests/database-cluster.spec.ts
@@ -27,7 +27,7 @@ test.beforeAll(async ({ request }) => {
     type: 'pmm',
     name: monitoringConfigName1,
     url: 'http://monitoring',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },

--- a/api-tests/tests/helpers.ts
+++ b/api-tests/tests/helpers.ts
@@ -68,7 +68,7 @@ export const createBackupStorage = async (request, name) => {
     region: 'us-east-2',
     accessKey: 'sdfs',
     secretKey: 'sdfsdfsd',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
   }
 
   const response = await request.post(`/v1/backup-storages`, { data: storagePayload })

--- a/api-tests/tests/monitoring-instances.spec.ts
+++ b/api-tests/tests/monitoring-instances.spec.ts
@@ -39,7 +39,7 @@ test('create monitoring instance with api key', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-key`,
     url: 'http://monitoring',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },
@@ -60,7 +60,7 @@ test('create monitoring instance with user/password', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-pass`,
     url: 'http://127.0.0.1:8888',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
     pmm: {
       user: 'admin',
       password: 'admin',
@@ -82,7 +82,7 @@ test('create monitoring instance missing pmm', async ({ request }) => {
     type: 'pmm',
     name: 'monitoring-fail',
     url: 'http://monitoring-instance',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
   }
 
   const response = await request.post('/v1/monitoring-instances', { data })
@@ -95,7 +95,7 @@ test('create monitoring instance missing pmm credentials', async ({ request }) =
     type: 'pmm',
     name: 'monitoring-fail',
     url: 'http://monitoring-instance',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
     pmm: {},
   }
 
@@ -244,7 +244,7 @@ test('update monitoring instances failures', async ({ request }) => {
     type: 'pmm',
     name: `${testPrefix}-fail`,
     url: 'http://monitoring',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },
@@ -301,7 +301,7 @@ async function createInstances(request: APIRequestContext, namePrefix: string, c
     type: 'pmm',
     name: '',
     url: 'http://monitoring-instance',
-    targetNamespaces: [testsNs],
+    allowedNamespaces: [testsNs],
     pmm: {
       apiKey: '123',
     },

--- a/api/backup_storage.go
+++ b/api/backup_storage.go
@@ -41,13 +41,13 @@ func (e *EverestServer) ListBackupStorages(ctx echo.Context) error {
 	for _, bs := range backupList.Items {
 		s := bs
 		result = append(result, BackupStorage{
-			Type:             BackupStorageType(bs.Spec.Type),
-			Name:             s.Name,
-			Description:      &s.Spec.Description,
-			BucketName:       s.Spec.Bucket,
-			Region:           s.Spec.Region,
-			Url:              &s.Spec.EndpointURL,
-			TargetNamespaces: s.Spec.TargetNamespaces,
+			Type:              BackupStorageType(bs.Spec.Type),
+			Name:              s.Name,
+			Description:       &s.Spec.Description,
+			BucketName:        s.Spec.Bucket,
+			Region:            s.Spec.Region,
+			Url:               &s.Spec.EndpointURL,
+			AllowedNamespaces: s.Spec.AllowedNamespaces,
 		})
 	}
 
@@ -120,7 +120,7 @@ func (e *EverestServer) CreateBackupStorage(ctx echo.Context) error { //nolint:f
 			Bucket:                params.BucketName,
 			Region:                params.Region,
 			CredentialsSecretName: params.Name,
-			TargetNamespaces:      params.TargetNamespaces,
+			AllowedNamespaces:     params.AllowedNamespaces,
 		},
 	}
 	if params.Url != nil {
@@ -144,13 +144,13 @@ func (e *EverestServer) CreateBackupStorage(ctx echo.Context) error { //nolint:f
 		})
 	}
 	result := BackupStorage{
-		Type:             BackupStorageType(params.Type),
-		Name:             params.Name,
-		Description:      params.Description,
-		BucketName:       params.BucketName,
-		Region:           params.Region,
-		Url:              params.Url,
-		TargetNamespaces: params.TargetNamespaces,
+		Type:              BackupStorageType(params.Type),
+		Name:              params.Name,
+		Description:       params.Description,
+		BucketName:        params.BucketName,
+		Region:            params.Region,
+		Url:               params.Url,
+		AllowedNamespaces: params.AllowedNamespaces,
 	}
 
 	return ctx.JSON(http.StatusOK, result)
@@ -219,13 +219,13 @@ func (e *EverestServer) GetBackupStorage(ctx echo.Context, backupStorageName str
 		})
 	}
 	return ctx.JSON(http.StatusOK, BackupStorage{
-		Type:             BackupStorageType(s.Spec.Type),
-		Name:             s.Name,
-		Description:      &s.Spec.Description,
-		BucketName:       s.Spec.Bucket,
-		Region:           s.Spec.Region,
-		Url:              &s.Spec.EndpointURL,
-		TargetNamespaces: s.Spec.TargetNamespaces,
+		Type:              BackupStorageType(s.Spec.Type),
+		Name:              s.Name,
+		Description:       &s.Spec.Description,
+		BucketName:        s.Spec.Bucket,
+		Region:            s.Spec.Region,
+		Url:               &s.Spec.EndpointURL,
+		AllowedNamespaces: s.Spec.AllowedNamespaces,
 	})
 }
 
@@ -298,8 +298,8 @@ func (e *EverestServer) UpdateBackupStorage(ctx echo.Context, backupStorageName 
 	if params.Description != nil {
 		bs.Spec.Description = *params.Description
 	}
-	if params.TargetNamespaces != nil {
-		bs.Spec.TargetNamespaces = *params.TargetNamespaces
+	if params.AllowedNamespaces != nil {
+		bs.Spec.AllowedNamespaces = *params.AllowedNamespaces
 	}
 
 	err = e.kubeClient.UpdateBackupStorage(c, bs)
@@ -310,13 +310,13 @@ func (e *EverestServer) UpdateBackupStorage(ctx echo.Context, backupStorageName 
 		})
 	}
 	result := BackupStorage{
-		Type:             BackupStorageType(bs.Spec.Type),
-		Name:             bs.Name,
-		Description:      params.Description,
-		BucketName:       bs.Spec.Bucket,
-		Region:           bs.Spec.Region,
-		Url:              &bs.Spec.EndpointURL,
-		TargetNamespaces: bs.Spec.TargetNamespaces,
+		Type:              BackupStorageType(bs.Spec.Type),
+		Name:              bs.Name,
+		Description:       params.Description,
+		BucketName:        bs.Spec.Bucket,
+		Region:            bs.Spec.Region,
+		Url:               &bs.Spec.EndpointURL,
+		AllowedNamespaces: bs.Spec.AllowedNamespaces,
 	}
 
 	return ctx.JSON(http.StatusOK, result)

--- a/api/everest-server.gen.go
+++ b/api/everest-server.gen.go
@@ -87,15 +87,14 @@ const (
 
 // BackupStorage Backup storage information
 type BackupStorage struct {
-	BucketName  string  `json:"bucketName"`
-	Description *string `json:"description,omitempty"`
-	Name        string  `json:"name"`
-	Region      string  `json:"region,omitempty"`
-
-	// TargetNamespaces List of namespaces allowed to use this backup storage
-	TargetNamespaces []string          `json:"targetNamespaces"`
-	Type             BackupStorageType `json:"type"`
-	Url              *string           `json:"url,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this backup storage
+	AllowedNamespaces []string          `json:"allowedNamespaces"`
+	BucketName        string            `json:"bucketName"`
+	Description       *string           `json:"description,omitempty"`
+	Name              string            `json:"name"`
+	Region            string            `json:"region,omitempty"`
+	Type              BackupStorageType `json:"type"`
+	Url               *string           `json:"url,omitempty"`
 }
 
 // BackupStorageType defines model for BackupStorage.Type.
@@ -108,19 +107,19 @@ type BackupStoragesList = []BackupStorage
 type CreateBackupStorageParams struct {
 	AccessKey string `json:"accessKey"`
 
+	// AllowedNamespaces List of namespaces allowed to use this backup storage
+	AllowedNamespaces []string `json:"allowedNamespaces"`
+
 	// BucketName The cloud storage bucket/container name
 	BucketName  string  `json:"bucketName"`
 	Description *string `json:"description,omitempty"`
 
 	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	Name      string `json:"name"`
-	Region    string `json:"region,omitempty"`
-	SecretKey string `json:"secretKey"`
-
-	// TargetNamespaces List of namespaces allowed to use this backup storage
-	TargetNamespaces []string                      `json:"targetNamespaces"`
-	Type             CreateBackupStorageParamsType `json:"type"`
-	Url              *string                       `json:"url,omitempty"`
+	Name      string                        `json:"name"`
+	Region    string                        `json:"region,omitempty"`
+	SecretKey string                        `json:"secretKey"`
+	Type      CreateBackupStorageParamsType `json:"type"`
+	Url       *string                       `json:"url,omitempty"`
 }
 
 // CreateBackupStorageParamsType defines model for CreateBackupStorageParams.Type.
@@ -645,10 +644,10 @@ type MonitoringInstance = MonitoringInstanceBaseWithName
 
 // MonitoringInstanceBase Monitoring instance information
 type MonitoringInstanceBase struct {
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                  `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceBaseType `json:"type,omitempty"`
-	Url              string                     `json:"url,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string                  `json:"allowedNamespaces,omitempty"`
+	Type              MonitoringInstanceBaseType `json:"type,omitempty"`
+	Url               string                     `json:"url,omitempty"`
 }
 
 // MonitoringInstanceBaseType defines model for MonitoringInstanceBase.Type.
@@ -656,13 +655,13 @@ type MonitoringInstanceBaseType string
 
 // MonitoringInstanceBaseWithName defines model for MonitoringInstanceBaseWithName.
 type MonitoringInstanceBaseWithName struct {
-	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	Name string `json:"name,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string `json:"allowedNamespaces,omitempty"`
 
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                          `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceBaseWithNameType `json:"type,omitempty"`
-	Url              string                             `json:"url,omitempty"`
+	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+	Name string                             `json:"name,omitempty"`
+	Type MonitoringInstanceBaseWithNameType `json:"type,omitempty"`
+	Url  string                             `json:"url,omitempty"`
 }
 
 // MonitoringInstanceBaseWithNameType defines model for MonitoringInstanceBaseWithName.Type.
@@ -670,14 +669,14 @@ type MonitoringInstanceBaseWithNameType string
 
 // MonitoringInstanceCreateParams defines model for MonitoringInstanceCreateParams.
 type MonitoringInstanceCreateParams struct {
-	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	Name string                     `json:"name,omitempty"`
-	Pmm  *PMMMonitoringInstanceSpec `json:"pmm,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string `json:"allowedNamespaces,omitempty"`
 
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                          `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceCreateParamsType `json:"type,omitempty"`
-	Url              string                             `json:"url,omitempty"`
+	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+	Name string                             `json:"name,omitempty"`
+	Pmm  *PMMMonitoringInstanceSpec         `json:"pmm,omitempty"`
+	Type MonitoringInstanceCreateParamsType `json:"type,omitempty"`
+	Url  string                             `json:"url,omitempty"`
 }
 
 // PMMMonitoringInstanceSpec defines model for .
@@ -697,12 +696,11 @@ type MonitoringInstancePMM struct {
 
 // MonitoringInstanceUpdateParams defines model for MonitoringInstanceUpdateParams.
 type MonitoringInstanceUpdateParams struct {
-	Pmm *PMMMonitoringInstanceSpec `json:"pmm,omitempty"`
-
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                          `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceUpdateParamsType `json:"type,omitempty"`
-	Url              string                             `json:"url,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string                          `json:"allowedNamespaces,omitempty"`
+	Pmm               *PMMMonitoringInstanceSpec         `json:"pmm,omitempty"`
+	Type              MonitoringInstanceUpdateParamsType `json:"type,omitempty"`
+	Url               string                             `json:"url,omitempty"`
 }
 
 // MonitoringInstanceUpdateParamsType defines model for MonitoringInstanceUpdateParams.Type.
@@ -718,15 +716,15 @@ type NamespaceList = []string
 type UpdateBackupStorageParams struct {
 	AccessKey *string `json:"accessKey,omitempty"`
 
+	// AllowedNamespaces List of namespaces allowed to use this backup storage
+	AllowedNamespaces *[]string `json:"allowedNamespaces,omitempty"`
+
 	// BucketName The cloud storage bucket/container name
 	BucketName  *string `json:"bucketName,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Region      *string `json:"region,omitempty"`
 	SecretKey   *string `json:"secretKey,omitempty"`
-
-	// TargetNamespaces List of namespaces allowed to use this backup storage
-	TargetNamespaces *[]string `json:"targetNamespaces,omitempty"`
-	Url              *string   `json:"url,omitempty"`
+	Url         *string `json:"url,omitempty"`
 }
 
 // Version Everest version info
@@ -2037,139 +2035,139 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
-	"H4sIAAAAAAAC/+x9+3PbNvbvv4JRvzNNuhJtJ+3Orn/ZsR1v69u69djO3rkb5zYQCUlYkwALgLKVNP/7",
-	"d3AA8AlK1MOOveEvbSyCeByc5wcHh58GIU9SzghTcnD4aSDDGUkw/PMYh7dZeqW4wFOif8BRRBXlDMcX",
-	"gqdEKErk4HCCY0mGg4jIUNBUPx8c2neRNC8jyiZcJBgeDgdp6e1Pg3EW3hL1K05gDLVIyeBwIJWgbDr4",
-	"XOvX85y1vSjI1PvOcHA/mvKR/nEkb2k64qlZ1CjllCkiBodKZOTzcKCwmJqZyRSHZrbVZf5CpUJ8glje",
-	"BuE45nckQoqjTBKkZlSicYUag+GAKpJI76ztD1gIvCj+/jQgLEsGh+8G8vVgOMAfM0EG74fN1zMRe7oF",
-	"avyRUUEi3QeQbFgmvO3Js+RiED7+DwmVHqTCGFLTQI+Zr+l/BJkMDgff7BWctWfZaq/KU571ngiCFak0",
-	"u8ACm543Z8BU90EUEbLBfzgMiZQ/k4V3P6rcWR3jekZQGPMsyocxrfdCzhSmjAjEStTdhKurAx5plhIo",
-	"IhPKiB5VN4cxNBOqGSkJHPz55tcr89iIH5oplcrDvb3bbEwEI4rIgPK9iIdSzzkkqZJ7fE7EnJK7vTsu",
-	"bimbju6omo3M7ss94PS9byImRzEek3gEPwyGA3KPkzSGvbyTo4jMfcveXiYlCQVRbbv1NUlswbdlqqwn",
-	"yW+wwmMsyUmcSaBynVy1BohK4KsrEGfNVfBnZFuFppVERxdnQVPQUvovIqRlgBpnX5zZZ5a7zThz85vm",
-	"dTMisDmVSJBUEEmYApuif8YMmXUF6IoI/SKSM57FEQo5mxOhkCAhnzL6Me9N6i3Xw8RYEakQcBrDMZrj",
-	"OCNDhFmEErxAguh+UcZKPUATGaBzLox5O8yFa0pVcPs3kKyQJ0nGqFqAShB0nCku5F5E5iTek3Q6wiKc",
-	"UUVClQmyh1M6gskyvSgZJNE3gkieiRAkrME6t5RFTVL+TFmk9wk7/QBTLSimf9KLvjy9ukauf0NVQ8Ci",
-	"qSxoqelA2YQI03IieAK9EBaBiMIfYUwJU0hm44QqvUl/ZEQqTeYAnWDGuEJjgrI0wopEATpj6AQnJD7B",
-	"kjw4JTX15EiTzEvLhCis2bgki4WYyJSEK2XjKiVhhXkjIrX8IqmwAgVde8EjIVoTvWUST8gJZxM6zQRW",
-	"fnlpaYkmlMSR1mOgzwiTmdCbi80GgfkIMUMhmFktGsW7EmVsQhVIdSp4lIXQYyZJUFBszHlMMAPTCDqy",
-	"OTdreq2qcJo0JSGd0NDvAxKGxzHxMPOpeWD4eRLjqVmV/tH2LL1zS6nyaLOLs+tLN6/K0p35NKysjSdN",
-	"CCiMORGLpstadk/8vsFxvYkbt2ytK43Q3YzAXhHk5unI4uHXjSim+/WSK0tjjqMzrf/mOL7ycfvbehPE",
-	"smRMhF6LJCFnkURjou4IMa7HmLKYTyUyXZd2SWvZKRENG+dW5LNTWl9HWewz6FfukVlxbO27Y7v8xZIJ",
-	"9+6UbVhnW/dzhV2CR+KIk0sjumWt4jy8mOeytBvmgM7tcr1M4vdJ21bS7KrsBiqjmU94Sn2belltkPef",
-	"c5zdntA8VhwJoj3uwXBgPF3DZ69fediu4KZ2ZsqVhOBsyUpqHNxkgmIrhs6Hy3vz8XnVl1xDQLTpugJL",
-	"7rdT5lnOSBhcNmRtv1b4Y86VVAKn2j3AiJE7ZL25Nl5vGe249LQuTNbV0Lul2ZiAG/FIsgQmEVZqzEbg",
-	"Y8wUq5nHbGA1cwPoFs5ttMua0JjsRVSQUHGxCDZiExjYu7Fj6y2Y1fjJ8ea40chHkDfHbk/d1Jtb0STJ",
-	"SksKRnNE2ahiNKsas7HJ2gX0smo+87fXJ5pLLb9Ap+BI6qhbxz6pMhuaYHWIbgav9vf/Oto/GO2/uj74",
-	"4XD/+8P9H/59M/DusovQIjLBWax1BcymDiFcL9J8MvoVTUa3ugBE2wR49mUTRHhivM+Nbf3s2WjCppQR",
-	"n8rWv7t5uEgLmeYr3CqzBc0+jcvo+rRd1ffLo7XTmIbYq67Nk6aetn3nr3r0c0IZTTQlD3y6ugiAPKPa",
-	"RwhbvymPZmIKAYgWd4LDWW0aATqbIB2MSKKGjZd0Z/ohTVIuQXPXiJpm4KuzxW+TweG7T81JN6L593XW",
-	"Orl462il/5lPwaqJBNBY0Ao6Ih0cDv7/i5ubv/w5evmPFy/e7Y/+/v4vL25uAvjXdy//8fLP/K+/vHz5",
-	"4sW7n89/vL44fU9f/vmOZcmt+evPF+/I6fvu/bx8+Y//AWCmAItGWtC5GNl1OUwmIQkXi62Jcg7dOLqY",
-	"Tp83aXxyLgs8veZ7OOiuIpXO3VuuTcMYS4+EnOifXYd5T/CjBbscgpMSIanUThea8zhLoBn1GgRJP5Kt",
-	"9/qKfsxXqjvMA7DWeTyXDS9beiBVu5/3aYnBsdtvwTxnatL7UJOCSzUVRP4R6z9kEo39yKIk4gqAQel3",
-	"G95WG3i9eHiMLKDtoCOAEcwjL5gyb4P5HMZXXaRrvspxKtBYaOcjbMIZVdzsSH3w8/xZrmOKX5bLV9HQ",
-	"mE4/Pc89repExajeFzq5DPzmtoPlcw591YhZOMcJdzFi4NMcNPGrDppICKeLBUjjAtnBh/lBBGXgiATu",
-	"kXl5aIJXbU/B+R4vDHaYn44E6Iaha/2TjkcZwnE6wxbBwixyKt/iII753iwYTmjoaHAUu0gYTQhWmSBo",
-	"ihUp+jb96UGSJFM6hArQmQIUjLN4gcaayw3qlc8MooMWvOCyvEgkyIQIwvRecKY5WmkTxtAFj640SSqt",
-	"ZZP+S4LqJJMKJViFswoHVYZJeRR4SO/E94JHOaxUJoXeD6BCgm8BV8CqYCE8xzQGSIAySSOCcGnLVgop",
-	"LGhlbFvTpZrNRglOR7dkIcu9NFvZbhKc6k6Nz9Z+Nri2mXomLlf9UAs8V/Pj2AJFCb7XfjXCCc8YYGIh",
-	"T9JMFW5yfvTlBd+XnRFWtOVeghmeklHe7aiQo72BhxPcucDXvm2X7nyktnEmIFq6cU7iIJTJ+6ES8YQq",
-	"GxiX5XaIKMCIOt4F58+yDJ0Y4acSkXsdHFEVL1xUSaIh4mpGxB2VEIZjpqOiGJxw2PqRswBwxhQUMwnN",
-	"aQ+5DwmJ7GCPymXdgu4Ua03oQ3zAYlVgUql4ak+5HC7mOXcQ/H7h6U//nOMl8Eclcq9GpNoUptpMCIqV",
-	"tz26o3GsLRdO05ja7dZ9T+mcMOtXBehIc05iznBQiK2/L4myh4Blk6A4cIvgsXHN7u1ZqDlmdpBXjj+E",
-	"bWdY3TAHs6aVkAO51zG4BxSB36udmbYrHDlqkclLzKY+z+rsovzcDeAOFc4uHIYpzPMXJ2dvLvXGwWgv",
-	"QUa0SnVUmwieVPdWgTWmEjFe9tXa3Y3KjEpHs3oyOIoEkVJPlKHKVBAX6I6qGc8UoLkqwfJ2CRjWTF8o",
-	"wDF3LL4UILPU128Pwbcak+I8nYucn0rBTKnf/GkX9GwzJMowyZcGoiqz6HGoHof6YjjUagjC8GoNgUg4",
-	"m3K98Bk2ts7aPAtGTMc8YyERXWHw6vkWIODe81+FVSZXp2BAs8pxKR9LIubrZWGEis7JVRtOd1R+XAfX",
-	"jNvA8nOWFwDPQKD50qd9Z1wqfwj4k33iRnAtS2kCbhCrboXWMP5sgYRI6V3MuXlg/D8lcDlTF+GxNh9e",
-	"l6d0PsSF8jg8XKjifEioLrPucHIrCI4WPgWMo0VT5UNrHSLLjufCFtlshyoVVzguG5XufbdwsGXZnI3g",
-	"Lxu9t1K9m3NbY/TjlnQdb7NuiX72KLVP9+vT/b66dD+bXbBu0p95LXhKSQ95isGK5ILykFzQKdWyUw8I",
-	"YTKb5UBU57GFG+BosL4z0LY7IU/SmCgfVHDiHuU2ghojbdLg/sPH6A5LlPcQlO2FlgxIm/Dti8nR9A1p",
-	"HpQHlAonqeOBLJVKEJzYXf9WmnRPm7jWbfCISEVZS/bpm+Khm8Qki2NPcoyX4aY49WzijziViEZahieQ",
-	"8zWxwTIGSD/VW6kF3jhYeZpkzKf+FFDYY7/BzdnYbX9+WwSrDswL83+/uQ12N2Y6MDFcVzCnI1ZbA1xn",
-	"oa8qOmHCcCpB5TfksqQBejv9oHY6B3I63Yjye2keYKY3/49i/jtI8YkgoKZw3NyPIhK39G3IW4qlvOMC",
-	"9rK4NCU4V4OWQ3wXIK5q3WHqnVTPzpROr22euLbp9cxT1jMX3tTblnRbQWJwCmG4xv0aLGJKpHpjXaJC",
-	"k7zaf/V6dPBq9Prg+tXrwx/+fvjD3//d2Un0O3KURTTUwlR14VKqBHhrNWcOT5Tbf5uVrP1lhW8J8/p1",
-	"Rk6r6dCNmZlGO11uhw27NLnUKxWsbdcNZLEJ2j3K0qMsXx/KYiVlbZjFvhf47h1sd1HGiOPya2D91Zj+",
-	"akx/NWZnV2PWAijLWqKMSZY2dDUflrTEDnFJp8w2ACZb9VkFmezmtZUOA5vJ/X7QrDTzSg5KPt2aVtzF",
-	"eZUds1PEWmq7G7TMOV29w/W0A1jncfdx7FOMY09b7jRWn68Ig0xaSB/+9OHPVxT+GMmAsMeQXf/L5HTX",
-	"rgC3VJEhkeX9qmpdI/2zeQkZvD6pMIuKu0UyS1MuHPBUmpcM0CWdzhRi/A5R9a00t23S+xBkAPKiAvQT",
-	"vyNzm55uE4JSOUTpFBphtjAJ6DY+Wu24tV4MW+WiWYKv45qdttHf3Z8p74D3Hpx2oERWkY7S7Zu5a8Qn",
-	"jXvfhWVsC0KXXa5onmBDX4WjVM4Cs75S6wyCnCDotPbIbWnt3WHxg8kx1LzEeSwRTUyxPjXzeLqCKhri",
-	"crW0EioIb/6E5czL5fD0wkawXqc3k/4qbG3XmHwX93tyPwK58xsWrTeH+l14+F1o/qCX0m/L09oWXxO9",
-	"DKy4KLnNSybhcwPaUQC7HZQhjG7/JsuXhLZCBMy4y5GAos12CIDzXvpQ42kG/jam7AP+pxTwnwrBPVA4",
-	"/KyJmnImSbOqQisQ6Rvj5zyzxmI/Z2zClybgODBPU9FT+AAeXtt4x6MD4RACSqhAFd3KQfK7wTR9NRgO",
-	"pulrHW50ja9q0Up5Dr4R33chw2X7xTQPLcoS2RK2QJJS/arZOY1jWl6iuQRRrtw8OBxklKm/fg+YPZW3",
-	"V/Y+Rbc3zEWr44UinYdpsEm5jrTJmiou5x3l6/s8HIQ4xSFVi//StZ645TU4zj0Ylvbbx2ZFLZMzpkN+",
-	"c56J49jeq1umqpvvHmNJ/i9VMzhB8dy4K1VmsW/UPhnQiPFN4WxPmWtbaPG9dw16HssLw/iHr7LIzqqM",
-	"J82Btyo1niZJ85Cte211W4o8oewXwqbaQT3YtLPPnViqwhZbshdc7exSW+UpF9F/GNJvIG8dNs/cQih9",
-	"nGEnumG47usX5+cdV2hrXj+IYtGzaJgSLY6NH3FK7dcLdrHZw0o68caCL03t/x0xnMcyXZyfN4l2lZJw",
-	"0FFVvAUveTfc9qBcZtz5Cpd5F7Ted1M85thjD3JubfS90pQY+n71311p+0DJs/jySOunRBry1QpknM6J",
-	"IFI55MIfOk2yOD7hSULVNkonFVxPx5/C272beRuOtYb6KhuB8rSK3oflRfv8ZcohNMcpTXA40zy4CNLb",
-	"qf5BBjqaDuYHgWaBc2Ki6iZz6CelUlAuBDcIllwwNSOKhqUiUFAgbobnZIgoC+Ms0orIVOzDLEJzLCjP",
-	"ZH6p3DgfAToqYI4EL6ADczbHGbhAn36Dlno6Q+Qm9tlb6UdRlnkE1D2B/m19PTopl45UUKo/oQpxVru1",
-	"D/yOBFGZYCQyMFaRUp5/ygJO5QSaYe1GC4PrFodnJhfOQD1UIp7iPzKSI2Jjkn8hg0oJD8wxo4VoHLBW",
-	"QnP0FphzQJBSwBBN2XlBydxUNmDkHmq5AJ6XH+PldD8xVDEF1kPOXKFT6EtPywJCKZeSQvm9SXml1Q9W",
-	"6HWHM8ymJEJcGBKoGWYIowm5QwllmSYXbK52EUhkSOK23sGVpv6To7a5t5rJvDxUvpOGlK7slLmmGeLY",
-	"UcpS2uzlhAqpcthniDIWEynRgmdmPoKEhOakVPyWMIOgYYYIQEYWGWqpi5mYUqRniiQnPGMeULjZplkd",
-	"QmZjqbdbPwOWs7OH7bib0XBWlOAB6XIXT932uwVCGZ/8TcdCzhZFCFx8vUmG1pLEkA4L9TEJa9SssDN3",
-	"k5IoY7eM3zHgXkNe3Y3biphMFMoYiBSL8vpvUQZuiSSC4ph+LKqM5ROlxaVk9IJQ4P8xCbG2RFSZElUK",
-	"hbOM6QBGz989VbZkp8GepW30sliPvfHBuOHL+prMQvLiYxutxAGxPI4AhMUMzQ+Cgx9QxF1JpdIYhve1",
-	"1md6G/UibKzn55TviFRUe29s+l2lRrEW3FjvH0ziBADeHKnX4woCirStb8WdPoRzJv0HucehCmpVRP76",
-	"/WBZEapW+31lollT06+4S12okW9l6ZzA6gB3KlE5MTGnZa5wa2hXqjhc3BEJZfaSu1VvRrKtRgrQv0Af",
-	"gIEaE6TshXWca+JSl5ANAhoKZSzhERQeBDfIKRcz8wBd8DQzl5yglCxBciEVSQJ0SXA00ibswWFzHeBn",
-	"QhAWLka2XN4Is2iUq/Nw4a2ZTeLJL5TdNjfMPTFHFG8vf6mfTOT70mn9N+yGvTm9uDw9Obo+fYMKsNhI",
-	"GdQw1FYcT3GjBiBDB8Grfc3BBEtSUzdUojTGjBmrCXV7Ej4n7rUD91rQ7eJUJ3fJZOOcaJ3TVjgHHuoV",
-	"zWlErCfQLGEEBRWp7Q9NMI0zUXGaQiw1iTQ/J1msaBoTY4lMGTbCQi29RJjyDTVvWNPHH6QY0uWaJj9b",
-	"wsrYb1NlEvYARhtqCdHxAewwVRL9n6vffq2rvnM4ewKLhCJulGXKpZrQ+6L+34QLxIgEqVOG04n2/XSs",
-	"YBb1kQg+oiwi91pg0T/1XM3BFk5Tgss+BTcAEdBRdwA1SfXkJYoyyKyfmLdneK7JWaNhgH6zrjfw56k5",
-	"RJGHNwyhG0BVbgZoVGK2/EerSI3IFSWKzYtgTN7tvw869GBcEjP5vHiy7eJmsFbJrCM0yxLMRoLgCBy8",
-	"0uO8chMumRggQoDK1aitE2oFHTTjyNTgxFC1yntmDuWvpPf4GVkpWntSZ1b1554ySVK1qFSprIhT7l/v",
-	"XMzfEIVpLH+fv2qTddvCHuZaNztHJlAhlUbCzo/+n7O1Tl0aR1pxpzDKr3u0RsnD09J8CdQvhBqjq3Jk",
-	"lZ/830HV81zocv9GElW4DGAa6ZTB/SIjPOZTX8Z9Kcp+O5zaXbOBMpJ57yY8sv4HljJLrH7BbFG0cvwG",
-	"m6v13hzHNBpqHyRjUQGGe2I8kHK/djsxGsAIlVVILhizW4Wl5CEFk3VHlVmQIZojptHFAfpVK7I4rjw1",
-	"2sjtlemTRFbzVCq0L4PO1jY1HmRlKrivdJqmAjwqkbqu7X0ksBF5ea1B92RsPap+soNB0W8MSZ4QZLKC",
-	"qKN5RCcTIoq0BhvUkKgY4mfKoi+dpcBa4UE4r9maPujFXRHRGLVD2TS23ZsY0aWVWdwmetmiuZVYHE0U",
-	"fHCD6+U0C/1OynW380pSlJU+rzjhtohivl9O9sEjU4JqW36ld9S6LyZRxaAn5aQU0D8K3xLz4QWICBRB",
-	"2Hzzc2Tzu7nMO1JV65X3OeN3KOYMSmTfYaryWeJbl1pT7z7oVjIxox7mf3v2pr6bQes25fvdtlV1/vWf",
-	"6mWSiNE0oxHZy2MqIb/JqI8rtzSDS+yfWZqBaqzBho9W4DjOjQf7VrkWBtFy6FOfzvbQ6Wwhj3xhSjad",
-	"Gs350/X1hdsb3daKGHUA7RDtI5rXg+4oI9bQ7tAGlvywPqduxzl1W0QU5cqwAGiT1tu21ey9rdkiP7TY",
-	"KgC5my1qM4dP8pjo7GbwT+MH3gzsQreITNCR89TDGAuDf2FmxM9SEcRvnGmFSQzMyedECO1lUuWl6Iry",
-	"vXaTil1Bv8FZyiG6GVxlcNCpY1FRXumDs6P2JgCcspPvkoStjZU3rfIbdJSpmUH99U837CiOy+KH3NHh",
-	"0cWZK5KOPuiXuLDQxSE6JlgQgW6y/f3XIQD/8E/yAc0g6jXeGEYQn9iTAcpQGmPKRorcKwAQrqESs35m",
-	"LTofW6h9vLCHFx+ImU2oYttUqxv1wXoC8Icr6ayfAoYiqI7MaH78I0NBCAtuICGGKiggdEFEyBnOV2tE",
-	"qXRSeDg4CPaDfZtqz3BKB4eD18F+8MrWsgAu2jPHvCN7zAu/TYlqPzU2XyM2MGr1iFhvbM54Z5F9p3KS",
-	"LyHRxcSyMNSr/X13gkfM+Ql8SMRs7d5/rIzbta1QItWRIPMA+KhuB0EKJllcSImm0fc7nInJQvYM/pbJ",
-	"luF/eIzhz5wnYwEIYhsOBzJLEiwWnfdZ4als1EmBlKSU+y5HmBwt+z3nanfOP9MC9d13DpP77jtA5T58",
-	"+KD/90n/p8DotDaTrx3P3gyG7rHWIu5x6ecih8M8NH8flFrkOSCmgfnz91v9d94mz7uwI8CftTYmbcM0",
-	"INkoJEwJHI8Obga6xed8ScvXhj9mgixdHrRYssI8AWXJIm3/v+MQQOXfzfity621LtZdrKqhAMy2VwRz",
-	"kH9265ibEvo74XnPSDZtyCMH16V6RxUmtEcKruBxOSHDZnk8jvbqFdf6imu1ilmitz4PG5Zw75MWiM9G",
-	"l8XEWwoJfjcm2iEmzbypqkiYd+oiUUpPO3zn/QijVcnNrCwoxYjVzOWFHroP/Fd5d1jag7r79b7B19/7",
-	"Asie/5bxXzdmaDecXq/rR6LWY68fiXrqvNXrzCfDsx3Ya4mnh1XorcQnFMWxyz92sEHLCAEyCb+2Kke1",
-	"qTmPChpM7skRfhp8vnu/pj0duptfA0SRAfqtjbr5qaCDqnqv5zlJ8HrStsIDsnczRw55WWqS3EVOOA+G",
-	"w9/yd/3NJ7oxat789Jks/5XaB+Q7/4A9/21sQbbgBseRt3+Tlg+L64gjd51lPWDKc5/Rj055rsM8JNu1",
-	"3b7pGW8nOFXLtjsGSzyb3Q5ZHfm6K46NwEJK9EEz/IcinTa4YcdYksjle7nn5pg4JfDNRnRLFgZhrubS",
-	"M0IiWenrKgtnCMshohPT1SFKk+SDzXD+oP8NnZXftHkqkcOwK2MErSiN52bXw7g0K25wtvg15+2b8eVA",
-	"G99tuF6Ut0Ju2oVupSS3mY5NkZxz7614H5zjlZ3O8UjL7fuvHNj53sz1YYf3aRXGFZrwjEVPH17yc+gq",
-	"e9cRaUo6sP+PRG3H++ePyPu93u8FqwsGlmwkVS1wmAFwNrAs5sUnbVkewzes1Fto8Q2TVb7hF8G2eiXx",
-	"36Mk1pDi1T4qqxRnaLXGOI7LNRoSzPDUpBbZnB8volEpFPNgvF0t8NGZrRuKd/UaaxQzvjz8+/Oeq5U5",
-	"csCl/W4QFLtZnofS8lnaltjY/23UNRRxPul29esef3Ed3PIhWL/qbaHjlw/NO6+iTQG/2j94/Mm4L2pb",
-	"tWzm8erx53FkP97UwxQemKJddzjdH3np/H4TXbYpeLFCr5l3nqZeGy4bsYX4kHSvdQ34DvY24blNP3/n",
-	"kuve559Z8y3cZSI+gwB0zYs8PSi5G7xlbYFvAVsu4faNXE9kfySql9dnKq9beyO9WBqx7Cg5uzTE7hN8",
-	"m0QV9t1uYcVl3vhriCvyL+Z1DCzcR1CfWmSxZB1fILRYMpvHjS2WTKQPLtYJLgoV0qLUHKU302rbxhdt",
-	"Gs4bYDwVDbeex+K+1ruVy3JZUV99jNELfWfBWin3G0UZbYLbDDN6qX2+kcYG3kkvnV1CjbXEM8284pnG",
-	"OFzXrpqTqF5CH0FCn0cIZM+2+xBo/RBoksW9wisrvG4KaZdxyHp5/XWJ8Cf11/hBPg1A5XFEsb9OsLvr",
-	"BD5ua+H9LqUv6t11AwW/EjSwsw18avDfEzF63axdvHhg1K+H+7aE+5aqmHXs6qa43kot5QX2nlfksV3E",
-	"0UN4vSAvh/DWEurO9zFWSmYTuevF8jlgdL3c7eLWxppCtwYkt1LwvJhcL3tPHH3bLOR4AnBbry92hW09",
-	"tPe9V7qQsDHIhVwnHbCu47xpr3ueSRZgj9g9HGJXEp0dZgTm0h0KAp9hwLFcWS6pXemgcjerffqTSute",
-	"zJ+8mBcb1ov5Qzj6NfnZrQFPqRIrZfuCU6ZGlI2uaUKQIHGujOy3NbYM4y/0JHpZfwayDjvVS/nGUr6t",
-	"JO1W+MuZ/5u773kvHfz3y6JtL+3PJbmu9+Af0IMvSc9O8k4Im1LWQaSL7+bnU3KvLpPj07zNf3/KiVlr",
-	"z/3bc/9SZquzvSH7euxeOg1eN0o1PSzzUk9di+dgsvLlPBdbY6nbS9guQ8ecC1qFq+WEyFsIaJWsVM+H",
-	"vnJxebhznXZJedrHOr2E77Qs1xpCri1o8S3VlRXvcYpDqhZQ37ww2XkHW1W8vyx90vXxyt4Xo/bct3nt",
-	"+835oln7fl58C7mVGd03H49xeEtY5L6HDJ/wbDCb/YDyQ39RwX3DefNacEtXBd2avTDWMhPx4HCwNz8Y",
-	"aLNi6Vgnlu5yoWaUTXMsyX5Ss5AEVLomYA2b3o2mfWzvzClyT1d1IGqjbougstarsxxbzBWVICf/nPP7",
-	"NNuMUhxM+wdxFVHWGOO4/mkT23P1yyaf33/+3wAAAP//6jMNuFv8AAA=",
+	"H4sIAAAAAAAC/+x9e3PbNvboV8Gov5kmXYm2k3Zn1//s2I639W3demxn79yNcxuIhCSsSYAFQNlKmu/+",
+	"GxwAfIIS9bBjb/hPYpEgHud9Dg4OPg1CnqScEabk4PDTQIYzkmD48xiHt1l6pbjAU6If4CiiinKG4wvB",
+	"UyIUJXJwOMGxJMNBRGQoaKrfDw7tt0iajxFlEy4SDC+Hg7T09acBjmN+R6JfcUJkikPzsNrbL1QqxCeI",
+	"5W2Q/QopjjJJkJpRicaVQQfDAVUkge7UIiWDw4FUgrLp4PPQPcBC4IX+Pc7CW6L0HLzNK9PxvGdtHwoy",
+	"9X4zHNyPpnykH47kLU1HPDWQHaWcMkXE4FCJjOQz/TQgLEsGh+8G8vVgOMAfM0EG74fNATMReyYCM/kj",
+	"o4JEug+YbmXRtqehBxvFKHz8HxIqPUqFNKRGjx40B/f/CDIZHA6+2Stoa88S1l6VqjyoOBEEK1JpdoEF",
+	"Nj1vToKp7oMoImSTAsOQSPkzWXhR+ATpszr69YygMOZZlK/VtN4LOVOYMiIQK+F4E7quDniklyRQRCaU",
+	"ET2qbg5jaCCoGSnxPfx88+uVeW2kAJoplcrDvb3bbEwEI4rIgPK9iIdSzzkkqZJ7fE7EnJK7vTsubimb",
+	"ju6omo0MCco9gPTeNxGToxiPSTyCB4PhgNzjJI0BdndyFJG5b9nbc6UkoSCqjWQei2cLwi3PaE1efoMV",
+	"HmNJTuJMwhLr6K41QFQCUq+AoTVK4WdkW4WmlURHF2dBk9VS+i8ipIV+jawuzuw7S1pmnLl5pgnNjAg0",
+	"RiUSJBVEEqZAr+jHmCGzrgBdEaE/RHLGszhCIWdzIhQSJORTRj/mvUnNoXqYGCsiFQI0MxyjOY4zMkSY",
+	"RSjBCySI7hdlrNQDNJEBOufCqLjDnLKnVAW3fwOyDnmSZIyqBfCjoONMcSH3IjIn8Z6k0xEW4YwqEqpM",
+	"kD2c0hFMlulFySCJvhFE8kyEQN4N2rmlLGqC8mfKIo0n7JgTplpATD/Si748vbpGrn8DVQPAoqksYKnh",
+	"QNmECNNyIngCvRAWAX/AjzCmhCkks3FClUbSHxmRSoM5QCeYMa7QmKAsjbAiUYDOGDrBCYlPsCQPDkkN",
+	"PTnSIPPCMiEKazIuMWPBJjIl4UreuEpJWCHeiEjNwEgqrEA61j4I/ObQWybxhJxwNqHTTGDl55eWlmhC",
+	"SRxpGQ3qhzCZCY1cbBAEsjvEDIWgaDVrFN9KlLEJVcDVqeBRFkKPmSRBAbEx5zHBDPQSqLTm3KzytaLC",
+	"Kb6UhHRCQ78dSBgex8RDzKfmhaHnSYynZlX6oe1ZeueWUuWRZhdn15duXpWlO91lSFlrLpoQEBhzIhaN",
+	"6Y7LBopfMR/Xm7hxy6qy0gjdzQjgiiA3TwcWD71uBDHdrxdcWRpzHJ1p+TfH8ZWP2t/WmyCWJWMi9Fok",
+	"CTmLJBoTdUeI0ftjymI+lch0XcKSlrJTIhpKzq3Ip6e0vI6y2Gd/XblXZsWxNccc2eUfliwuL6ZswzrZ",
+	"uscVcgkeiSJOLg3rlqWKM69invPSbogDOrfL9RKJ3yBsW0mzq7INpoxkPuEp9SH1stog7z+nOIue0LxW",
+	"HAmizd3BcGDMTENnr195yK6gpnZiyoWE4GzJSmoU3CSCAhVDZ8TlvfnovGr6r8EgWnVdgSb36ynzLick",
+	"DCYbsrpfC/wx50oqgVNtHmDEyB2y1lwbrbeMdlx6W2cma2pobGkyJmBGPBIvgUqElRq1EfgIM8Vq5lEb",
+	"WM3cALqFMxvtsiY0JnsRFSRUXCyCjcgEBvYidmytBbMaPzjeHDca+QDy5tjh1E29iYomSFZqUlCaI8pG",
+	"FaVZlZgNJGsT0Euq+czfXp9oKrX0Ap2CIaldXu38pMogNMHqEN0MXu3v/3W0fzDaf3V98MPh/veH+z/8",
+	"+2bgxbJz0SIywVmsZQXMph5EuF6k+WT0JxqMbnUBsLbx8OzHxonwOHmfG2j97EE0YVPKiE9k6+duHs7T",
+	"Qqb5CrPKoKDZpzEZXZ+2qzq+PFI7jWmIveLavGnKadt3/qlHPieU0URD8sAnqwsHyDOqfYWwtZtybyam",
+	"4IBodic4nNWmEaCzCdLOiCRq2PhId6Zf0iTlEiR3DahpBrY6W/w2GRy++9ScdMOdf18nrZOLtw5W+s98",
+	"ClZMJBCRBamgPdLB4eD/v7i5+cufo5f/ePHi3f7o7+//8uLmJoC/vnv5j5d/5r/+8vLlixfvfj7/8fri",
+	"9D19+ec7liW35tefL96R0/fd+3n58h//A1GRIlIz0ozOxciuywVEEpJwsdgaKOfQjYOL6fR5g8bH57KI",
+	"qddsDxc3q3ClM/eWS9MwxtLDISf6sesw7wke2tiki+CkREgqtdGF5jzOEmhGvQpB0o9ka1xf0Y/5SnWH",
+	"uQPWOo/ngvCypgdQtdt5n5YoHIt+G81zqia9DzUouFRTQeQfsf4hk2jsDy1KIq4gMij9ZsPbagOvFQ+v",
+	"kY0mu9ARhBHMK28wZd4W5nMxvuoiXfNVhlMRPId2PsAmnFHFDUbqg5/n73IZUzxZzl9FQ6M6/fA897Sq",
+	"AxWjel/o5DLwq9sOms8Z9FUlZsM5jrmLEQOf5KCJX3TQRII7XSxAGhPIDj7MdwEoA0MkcK/Mx0PjvGp9",
+	"Csb3eGFih/nWRIBuGLrWj7Q/yhCO0xm2ESzMIifybRzEEd+bBcMJDR0MjmLnCaMJwSoTBE2xIkXfpj89",
+	"SJJkSrtQATpTEAXjLF6gsaZyE/XKZwbeQUu84LK8SCTIhAjCNC440xSttApj6IJHVxokldayCf8lTnWS",
+	"SYUSrMJZhYIqw6Q8Cjygd+x7waM8rFQGhcYHQCHBtxBXwKogITzHNIaQAGWSRgThEspWMiksaKVvW5Ol",
+	"msxGCU5Ht2Qhy700W9luEpzqTo3N1r47uLaaeiYmV30PEixX83BsA0UJvtd2NcIJzxjExEKepJkqzOR8",
+	"p9IbfF+2QVeRlnsJZnhKRnm3o4KP9gYeSnD7Al872i7d/kgNccYhWoo4x3HgyuT9UIl4QpV1jMt8O0QU",
+	"woja3wXjz5IMnRjmpxKRe+0cURUvnFdJoiHiakbEHZXghmOmvaIYjHBA/chpANhjCoqZhGa3h9yHhER2",
+	"sEelsm5Od4q1JPRFfEBjVcKkUvHU7nK5uJhn30Hw+4WnP/04j5fAj4rnXvVItSpMtZoQFCtve3RH41hr",
+	"LpymMbXo1n1P6Zwwa1cF6EhTTmL2cFCIrb0vibKbgGWVoDhQi+CxMc3u7V6o2Wd2Ia88/hC27WF1izmY",
+	"Na0MOZB77YN7giLwvNqZabvCkKM2MnmJ2dRnWZ1dlN+7AdymwtmFi2EK8/7FydmbS404GO0l8IgWqQ5q",
+	"E8GTKm4VaGMqEeNlW63d3KjMqLQ1qyeDo0gQKfVEGapMBXGB7qia8UxBNFclWN4uCYYV2SbN4JjbFl8a",
+	"ILPQ118PwbYak2I/nYucnkrOTKnf/G2X6NlmkShDJF86EFWZRR+H6uNQXywOtToEYWi1FoFIOJtyvfAZ",
+	"NrrO6jwbjJiOecZCIrqGwav7WxAB9+7/KqwyuToFA5pVtkv5WBIxXy8LI1R0Tq7a4nRH5df14JoxG1i+",
+	"z/ICwjPgaL70Sd8Zl8rvAv5k37gRXMtSmoAbxIpboSWMP1sgIVJ6F3NuXhj7TwlcztZFeKzVh9fkKe0P",
+	"caE8Bg8XqtgfEqrLrDvs3AqCo4VPAONo0RT50Fq7yLLjvrCNbLaHKhVXOC4rle59t1CwJdmcjOCX9d5b",
+	"od7NuK0R+nFLuo63WbdEP7uV2qf79el+X126n80uWDfpz3wWPKWkhzzFYEVyQXlILuiUat6pO4Qwmc1y",
+	"IKrz2MIMcDBY3xhow07IkzQmyhcqOHGvch1BjZI2aXD/4WN0hyXKewjK+kJzBqRN+PBicjR9Q5oX5QGl",
+	"wknqaCBLpRIEJxbr30qT7mkT17oNHhGpKGvJPn1TvHSTmGRx7EmO8RLcFKceJP6IU4lopHl4AjlfE+ss",
+	"YwjppxqVmuGNgZWnScZ86k8BBRz7FW5Oxg79+XkRrDoQL8z//eY62J2Z6UDEcLrE7I5YaQ3hOhv6qkYn",
+	"jBtOJYj8Bl+WJECvpx9UT+eBnE5novxWmicw06v/R1H/Hbj4RBAQUzhu4qPwxC18G/yWYinvuABcFieW",
+	"BOdq0LKJ7xzEVa07TL2T6NmZ0OmlzROXNr2cecpy5sKbetuSbitIDEYhDNc4X4NFTIlUb6xJVEiSV/uv",
+	"Xo8OXo1eH1y/en34w98Pf/j7vzsbiX5DjrKIhpqZqiZcSpUAa61mzOGJcvi3WcnaXlb4ljCvXWf4tJoO",
+	"3ZiZabTT5XZA2KXJpV4pYG27bkEWm6DdR1n6KMvXF2WxnLJ2mMV+F/jOHWx3UMaw4/JjYP3RmP5oTH80",
+	"ZmdHY9YKUJalRDkmWULoajosSYkdxiWdMNsgMNkqzyqRyW5WW2kzsJnc7w+alWZeyUHJp1uTirvYr7Jj",
+	"dvJYS213Ey1zRldvcD1tB9ZZ3L0f+xT92NOWM43V9yvcIJMW0rs/vfvzFbk/hjPA7TFg13+ZnO7aEeCg",
+	"raiepf2qaF0j/bN5CBmsPqkwi4qzRTJLUy5c4Kk0LxmgSzqdKcT4HaLqW2lO26T3IfAA5EUF6Cd+R+Y2",
+	"Pd0mBKVyiNIpNMJsYRLQrX+02nBrPRi2ykSzAF/HNDttg787P1PGgPccnDagRFbhjtLpm7lrxCeNc9+F",
+	"ZmxzQpcdrmjuYENfhaFUzgKztlLrDIIcIOi09sqhtPbtsHhgcgw1LXEeS0QTU65PzTyWrqCKhrhcLq0U",
+	"FYQvf8Jy5qVyeHthPViv0ZtJfxm2tmNMvoP7PbgfAdz5CYvWk0M9Fh4eC80Heik9Wp4WWnxN9DKw4qJk",
+	"Ni+ZhM8MaI8CWHRQhjC6/ZssHxLaKiJgxl0eCSjabBcBcNZL72o8Tcff+pS9w/+UHP5TIbgnFA6PNVBT",
+	"ziRpVlVoDUT6xvg5z6yxsZ8zNuFLE3BcME9D0VP4AF5eW3/HIwNhEwJKqEAV3cpG8rvBNH01GA6m6Wvt",
+	"bnT1r2reSnkOvhHfdwHDZfvBNA8syhzZ4rZAklL9qNk5jWNaXqI5BFEumzw4HGSUqb9+DzF7Km+v7HmK",
+	"bl+Yg1bHC0U6D9Mgk3IRZ5M1VRzOO8rX93k4CHGKQ6oW/6VrPXHLa1CcezEs4dtHZkUtkzOmXX6zn4nj",
+	"2J6rWyaqm98eY0n+L1Uz2EHxnLgrVWaxX9SuDWj4+KZytq/Ota20+N67CD2R5ZVh/OM/1LUFSXPktWrD",
+	"16uNp0nS3GbrXtrcViNPKPuFsKk2UQ827exzJ6KqEMaWBAaHO7tUV3nKNewfBvQbcFwH5JlzCKULGnYi",
+	"HYbrfn5xft5xhbbq9cOIFj2NhjbR/Nh4iFNqbw/YBbaHlYzijTlfmvL/O6I4j3K6OD9vAu0qJeGgo6x4",
+	"C4bybsjtQcnMWPQVMvMuaL3LUzwa2aMQcmpt9L1Slxj49pevPIXLV9puKVl5/UjrfSINBmsNZpzOiSBS",
+	"ueiF332aZHF8wpOEqm2kTiq4no4/jbd7N/O2WNYa8qusBsrTKnoflhfts5kpB/ccpzTB4UzjfxGkt1P9",
+	"QAbaow7mB4Em2XNiPOsmMes3pXJQzg03USy5YGpGFA1LhaCgSNwMz8kQURbGWaQlkanah1mE5lhQnsn8",
+	"YLkxPwJ0VIQ6EryADsz+HGdgBH36DVrq6QyRm9hnb7UfRVnmYQ73Bvq3NfbopFw+UkG5/oQqxFnt5D7w",
+	"JxJEZYKRyISyirTy/DoL2JkTaIa1IS1MbLfYQDP5cCbcQyXiKf4jI3lUbEzyWzKolPDCbDXaMI0LrpUi",
+	"OhoFZi8QpArEEU3peUHJ3FQ3YOQe6rlATC/fysvhfmKgYoqsh5y5YqfQl56WDQqlXEoKJfgm5ZVWL63Q",
+	"6w5nmE1JhLgwIFAzzBBGE3KHEsoyDS5ArrYRSGRA4lDvQpamBpSDtjm7msm8RFSOSQNKV3rKHNUMcewg",
+	"ZSFtcDmhQqo89DNEGYuJlGjBMzMfQUJCc1AqfkuYiaJhhgiEjWx0qKU2ZmLKkZ4pkpzwjHkCw802zQoR",
+	"MhtLjW79DkjOzh7QcTej4awowwPc5Q6fOvS7BUIpn/xLR0JOD0QIjHyNJANrSWJIiYUamYQ16lbYmbtJ",
+	"SZSxW8bvGFCvAa/uxqEiJhOFMgYsxaK8BlyUgV0iiaA4ph+LSmP5RGlxMBm9IBTof0xCrDUnVaZMlULh",
+	"LGPahdHzd2+VLdtp4s/SNnpZrMee+mDc0GV9TWYheQGyjVbigrE8jiAQixmaHwQHP6CIu7JKpTEM7Wup",
+	"zzQa9SKst+enlO+IVFSbb2z6XaVOsWbcWOMPJnECQd48Wq/HFQQEaVvfijt5CHtN+ge5x6EKapVE/vr9",
+	"YFkhqlb9fWX8WVPXrzhPXYiRb2Vpr8DKALczUdk1MTtmrnhraFeqOBzeEQll9qC7FW+Gs61ECtC/QB6A",
+	"ghoTpOyhdZxL4lKXkBECEgplLOERFB8Es80JFzPzAF3wNDMHnaCcLEFyIRVJAnRJcDTSKuzBQ+faxc+E",
+	"ICxcjGzJvBFm0SgX5+HCWzebxJNfKLttIsy9MdsUby9/qe9O5HjptP4bdsPenF5cnp4cXZ++QUXA2HAZ",
+	"1DHUWhxPcaMOIEMHwat9TcEES1ITN1SiNMaMGa0JtXsSPifuswP3WdDt8FQnc8lk5JxomdNWPAde6hXN",
+	"aUSsJdAsYwRFFantD00wjTNRMZpCLDWIND0nWaxoGhOjiUwpNsJCzb1EmBIONWtYw8fvIBjQ5ZIm31/C",
+	"yuhvU2kScACjDTWHaLcBMEyVRP/n6rdf66LvHPafQCOhiBthmXKpJvS+qAE44QIxIoHrlKF0om0/7duY",
+	"RX0kgo8oi8i9Zlj0Tz1Xs7mF05Tgsk3BTYgI4Kg7gLqkevISRRlk10/M1zM81+CswTBAv1nTG+jz1Gyk",
+	"yMMbhtANhFVuBmhUIrb8oRWkhuWKMsXmQ1Am7/bfBx16MCaJmXxeQNl2cTNYq2zWEZplCWYjQXAEBl7p",
+	"dV69CZdUDAAhQOWK1NYItYwOknFk6nBiqFzl3TeHEljSuwWNLBetPakzK/pzS5kkqVpUKlVW2Cm3r3fO",
+	"5m+IwjSWv89ftfG6bWE3dK2ZnYcmUMGVhsPOj/6f07VOXBpDWnEnMMqfe6RGycLT3HwJ0C+YGqOrsmeV",
+	"7/7fQeXznOly+0YSVZgMoBrplMEZI8M85rovY74Upb9dpNodtYFSknnvxj2y9geWMkusfMFsUbRy9AbI",
+	"1XJvjmMaDbUNkrGoCId7fDzgcr90OzESwDCVFUjOGbOowlLykILKuqPKLMgAzQHTyOIA/aoFWRxX3hpp",
+	"5HBl+iSRlTyVKu3LYmdrqxpPJGgquK98moYCvCqBui7tfSCwHnl5rUH3hGw9qn6zg0HRbwxJnhBkMoOo",
+	"g3lEJxMiitQG69SQqBjiZ8qiL52pwFpDc7BjszV80Iu7wqMxYoeyaWy7Nz6iSy2zcZvoZYvkVmJxNFFw",
+	"6QbXy2kW+52Ua2/n1aQoK12xOOG2kGKOL8f7YJEpQbUuv9IYteaLSVYx0ZNyYgrIH4Vvibl8ATwCRRA2",
+	"936ObI43l3lHqqq98j5n/A7FnEGZ7DtMVT5LfOvSa+rdB93KJmbUQ/xvz97UsRm0oinHdxuq6vTr39fL",
+	"JBGjaUYjspf7VEJ+k1EfVW6pBpfoP7M0E6qxChsursBxnCsP9q1yLUxEy0Wf+pS2h05pC3nkc1Oy6dRI",
+	"zp+ury8cbnRby2LUBWiHaB/RvCZ0Rx6xinaHOrBkh/V5dTvOq9vCoyhXh4WANmk9cVvN4NuaLPJNi60c",
+	"kLvZojZzuJbHeGc3g38aO/BmYBe6hWeCjpylHsZYmPgXZob9LBSB/caZFpjEhDn5nAihrUyqvBBdUcLX",
+	"IqnACvoN9lIO0c3gKoOdTu2LivJKH5wctTUBwSk7+S6J2FpZeVMrv0FHmZqZqL9+dMOO4rjMfshtHR5d",
+	"nLlC6eiD/ogLG7o4RMcECyLQTba//zqEwD/8ST6gGXi9xhrDCPwTuzNAGUpjTNlIkXsFAYRrqMas31mN",
+	"zsc21D5e2M2LD8TMJlSxbarFjfpgLQH44co667cQQxFUe2Y03/6RoSCEBTeQEkMVFBG6ICLkDOerNaxU",
+	"2ik8HBwE+8G+TbdnOKWDw8HrYD94ZetZABXtmW3pkd08hmdTotp3uc2NxCaMWt3S1ojNCe8sst9UtvIl",
+	"pLoYXxaGerW/73bwiNk/gctEDGr3/mN53K5thRCpjgSpB0BHdT0IXDDJ4oJLNIy+3+FMTCayZ/C3TLYM",
+	"/8NjDH/mLBkbgCC24XAgsyTBYtEZzwpPZaNWCuQkpdx3QMJkadk7navdOftMM9R337mY3HffQVTuw4cP",
+	"+r9P+p8iRqelmXztaPZmMHSvtRRxr0uPi/wJ89L8Pii1yJNATAPz8/db/Ttvk+c82BHgZ62NSZkwDUg2",
+	"CglTAsejg5uBbvE5X9LyteGPmSBLlwctlqwwT/5Yskjb/+84hKDy72b81uXWWhfrLlbVEAAG7RXGHORX",
+	"bx1zU0Z/JzTvGcnmDXn44LpU86hChHZLwRU9Lidk2CyPx5FeveBaX3CtFjFL5NbnYUMT7n3SDPHZyLKY",
+	"eMshwXOjol3EpJnnVWUJ802dJUr5aYfvvBcxWpHczCKDcoxYzVxi6KG75L9Ku8MSDurm1/sGXX/vcyB7",
+	"+ltGf92IoV1xeq2uH4laj7x+JOqp01YvM58MzXYgryWWHlahtxqfUBTHLgHZhQ1aRgiQyfi1lTmqTc1+",
+	"VNAgck+S8NOg893bNe350N3sGgCKDNBvbdDNdwVdqKq3ep4TB6/HbSssIHs+c+QiL0tVkjvMCfvBsPlb",
+	"vtvfXNONUfP0p09l+Y/VPiDd+Qfs6W9jDbIFNTiKvP2btHRYHEgcufMs6wWmPCca/dEpz3mYhyS7tuM3",
+	"PeHtJE7VgnZHYIkH2e0hqyNfd8W2EWhIiT5ogv9QpNMGN+wYSxK5fC/33mwTpwTubUS3ZGEizNVcekZI",
+	"JCt9XWXhDGE5RHRiujpEaZJ8sBnOH/Tf0Fn5S5unErkYdmWMoDVK4zna9TAmzYoznC12zXk7Mr5c0MZ3",
+	"HK5n5a0iN+1Mt5KT21THppGcc++5eF84x8s7nf2RlvP3X3lg53sz14cd3idVGFdowjMWPf3wkp9CV+m7",
+	"jpGmpAP5/0jUdrR//oi038v9nrG6xMCSjbiqJRxmAjgbaBbz4ZPWLI9hG1YKLrTYhskq2/CLxLZ6IfHf",
+	"IyTW4OLVNiqrFJNo1cY4jss1JRLM8NSkFtmcH29Eo1Ip5sFou1rhozNZNwTv6jXWIGZsefj7856rlzly",
+	"gUt7dxBUu1meh9JyNW2Lb+y/H3UNQZxPul38utdfXAa3XAbrF70tcPzyrnnnVbQJ4Ff7B48/GXerthXL",
+	"Zh6vHn8eR/YCpz5M4QlTtMsOJ/sjL5zfbyLLNg1erJBr5punKdeGy0ZsAT4k3WtZA7aDPU14btPP37nk",
+	"uvf5VWu+hbtMxGfggK55kKcPSu4m3rI2w7cEWy7h9I1cj2V/JKrn12fKr1tbIz1bGrbsyDm7VMTuGr5N",
+	"vAr7bTe34jJv/DX4FfmteR0dC3cR6lPzLJas4wu4Fktm87i+xZKJ9M7FOs5FIUJahJqD9GZSbVv/ok3C",
+	"eR2MpyLh1rNY3I29W5kslxXx1fsYPdN3ZqyVfL+Rl9HGuE03o+fa5+tpbGCd9NzZxdVYiz3TzMueaYzD",
+	"dfWq2YnqOfQROPR5uEB2b7t3gdZ3gSZZ3Au8ssDrJpB26Yesl9df5wh/Un+NHuTTCKg8Div2xwl2d5zA",
+	"R20ttN+l9EW9u25Bwa8kGthZBz618N8TUXrdtF28eOCoXx/u2zLct1TErKNXN43rrZRS3sDe8/I8tvM4",
+	"+hBez8jLQ3hrMXXn8xgrObMZuevZ8jnE6Hq+28WpjTWZbo2Q3ErG88bket574tG3zVyOJxBu6+XFrmJb",
+	"D21975UOJGwc5EKukw6xruO8aS97nkkWYB+xe7iIXYl1dpgRmHN3KAhcw4BjubJcUrvQQeVuVtv0J5XW",
+	"PZs/eTYvENaz+UMY+jX+2a0CT6kSK3n7glOmRpSNrmlCkCBxLozs3RpbuvEXehI9rz8DXgdM9Vy+MZdv",
+	"y0m7Zf5y5v/m5nveSwf7/bJo23P7c0mu6y34B7TgS9yzk7wTwqaUdWDp4t78fEru02V8fJq3+e9POTFr",
+	"7al/e+pfSmx1sjdgX4/cS7vB63qppodlVuqpa/EcVFa+nOeiayx0ew7bpeuYU0Erc7XsEHkLAa3iler+",
+	"0FfOLg+3r9POKU97W6fn8J2W5VqDybUGLe5SXVnxHqc4pGoB9c0LlZ13sFXF+8vSla6PV/a+GLWnvs1r",
+	"329OF83a9/PiLuRWYnR3Ph7j8JawyN2HDFd4NojNXqD80DcquDucN68Ft3RV0K3BhdGWmYgHh4O9+cFA",
+	"qxULxzqwdJcLNaNsmseS7JWaBSeg0jEBq9g0Npr6sb0zJ8g9XdUDURt1WziVtV6d5thirqgUcvLPOT9P",
+	"s80oxca0fxBXEWWNMY7rV5vYnqs3m3x+//l/AwAA//9WYswOY/wAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/monitoring_instance.go
+++ b/api/monitoring_instance.go
@@ -73,10 +73,10 @@ func (e *EverestServer) CreateMonitoringInstance(ctx echo.Context) error {
 	}
 
 	result := MonitoringInstance{
-		Type:             MonitoringInstanceBaseWithNameType(params.Type),
-		Name:             params.Name,
-		Url:              params.Url,
-		TargetNamespaces: params.TargetNamespaces,
+		Type:              MonitoringInstanceBaseWithNameType(params.Type),
+		Name:              params.Name,
+		Url:               params.Url,
+		AllowedNamespaces: params.AllowedNamespaces,
 	}
 
 	return ctx.JSON(http.StatusOK, result)
@@ -128,7 +128,7 @@ func (e *EverestServer) createMonitoringK8sResources(
 				URL: params.Url,
 			},
 			CredentialsSecretName: params.Name,
-			TargetNamespaces:      *params.TargetNamespaces,
+			AllowedNamespaces:     *params.AllowedNamespaces,
 		},
 	})
 	if err != nil {
@@ -154,10 +154,10 @@ func (e *EverestServer) ListMonitoringInstances(ctx echo.Context) error {
 	for _, mc := range mcList.Items {
 		mc := mc
 		result = append(result, &MonitoringInstance{
-			Type:             MonitoringInstanceBaseWithNameType(mc.Spec.Type),
-			Name:             mc.Name,
-			Url:              mc.Spec.PMM.URL,
-			TargetNamespaces: &mc.Spec.TargetNamespaces,
+			Type:              MonitoringInstanceBaseWithNameType(mc.Spec.Type),
+			Name:              mc.Name,
+			Url:               mc.Spec.PMM.URL,
+			AllowedNamespaces: &mc.Spec.AllowedNamespaces,
 		})
 	}
 	return ctx.JSON(http.StatusOK, result)
@@ -177,10 +177,10 @@ func (e *EverestServer) GetMonitoringInstance(ctx echo.Context, name string) err
 	}
 
 	return ctx.JSON(http.StatusOK, &MonitoringInstance{
-		Type:             MonitoringInstanceBaseWithNameType(m.Spec.Type),
-		Name:             m.Name,
-		Url:              m.Spec.PMM.URL,
-		TargetNamespaces: &m.Spec.TargetNamespaces,
+		Type:              MonitoringInstanceBaseWithNameType(m.Spec.Type),
+		Name:              m.Name,
+		Url:               m.Spec.PMM.URL,
+		AllowedNamespaces: &m.Spec.AllowedNamespaces,
 	})
 }
 
@@ -237,8 +237,8 @@ func (e *EverestServer) UpdateMonitoringInstance(ctx echo.Context, name string) 
 	if params.Url != "" {
 		m.Spec.PMM.URL = params.Url
 	}
-	if params.TargetNamespaces != nil {
-		m.Spec.TargetNamespaces = *params.TargetNamespaces
+	if params.AllowedNamespaces != nil {
+		m.Spec.AllowedNamespaces = *params.AllowedNamespaces
 	}
 	err = e.kubeClient.UpdateMonitoringConfig(c, m)
 	if err != nil {
@@ -249,10 +249,10 @@ func (e *EverestServer) UpdateMonitoringInstance(ctx echo.Context, name string) 
 	}
 
 	return ctx.JSON(http.StatusOK, &MonitoringInstance{
-		Type:             MonitoringInstanceBaseWithNameType(m.Spec.Type),
-		Name:             m.Name,
-		Url:              m.Spec.PMM.URL,
-		TargetNamespaces: &m.Spec.TargetNamespaces,
+		Type:              MonitoringInstanceBaseWithNameType(m.Spec.Type),
+		Name:              m.Name,
+		Url:               m.Spec.PMM.URL,
+		AllowedNamespaces: &m.Spec.AllowedNamespaces,
 	})
 }
 

--- a/api/validation.go
+++ b/api/validation.go
@@ -261,17 +261,17 @@ func azureAccess(ctx context.Context, l *zap.SugaredLogger, accountName, account
 	return nil
 }
 
-func validateTargetNamespaces(targetNamespaces, namespaces []string) error {
-	for _, targetNamespace := range targetNamespaces {
+func validateAllowedNamespaces(allowedNamespaces, namespaces []string) error {
+	for _, allowedNamespace := range allowedNamespaces {
 		found := false
 		for _, namespace := range namespaces {
-			if targetNamespace == namespace {
+			if allowedNamespace == namespace {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return fmt.Errorf("unknown namespace '%s'", targetNamespace)
+			return fmt.Errorf("unknown namespace '%s'", allowedNamespace)
 		}
 	}
 
@@ -313,8 +313,8 @@ func validateUpdateBackupStorageRequest(ctx echo.Context, bs *everestv1alpha1.Ba
 		url = params.Url
 	}
 
-	if params.TargetNamespaces != nil {
-		if err := validateTargetNamespaces(*params.TargetNamespaces, namespaces); err != nil {
+	if params.AllowedNamespaces != nil {
+		if err := validateAllowedNamespaces(*params.AllowedNamespaces, namespaces); err != nil {
 			return nil, err
 		}
 	}
@@ -369,7 +369,7 @@ func validateCreateBackupStorageRequest(ctx echo.Context, namespaces []string, l
 		}
 	}
 
-	if err := validateTargetNamespaces(params.TargetNamespaces, namespaces); err != nil {
+	if err := validateAllowedNamespaces(params.AllowedNamespaces, namespaces); err != nil {
 		return nil, err
 	}
 
@@ -396,8 +396,8 @@ func validateCreateMonitoringInstanceRequest(ctx echo.Context) (*CreateMonitorin
 		return nil, ErrInvalidURL("url")
 	}
 
-	if params.TargetNamespaces == nil || len(*params.TargetNamespaces) == 0 {
-		return nil, errors.New("targetNamespaces is required")
+	if params.AllowedNamespaces == nil || len(*params.AllowedNamespaces) == 0 {
+		return nil, errors.New("allowedNamespaces is required")
 	}
 
 	switch params.Type {
@@ -429,8 +429,8 @@ func validateUpdateMonitoringInstanceRequest(ctx echo.Context) (*UpdateMonitorin
 		}
 	}
 
-	if params.TargetNamespaces != nil && len(*params.TargetNamespaces) == 0 {
-		return nil, errors.New("targetNamespaces cannot be empty")
+	if params.AllowedNamespaces != nil && len(*params.AllowedNamespaces) == 0 {
+		return nil, errors.New("allowedNamespaces cannot be empty")
 	}
 
 	if err := validateUpdateMonitoringInstanceType(params); err != nil {
@@ -613,7 +613,7 @@ func (e *EverestServer) validateBackupStoragesAccess(ctx context.Context, namesp
 		return nil, fmt.Errorf("could not validate backup storage %s", name)
 	}
 
-	for _, ns := range bs.Spec.TargetNamespaces {
+	for _, ns := range bs.Spec.AllowedNamespaces {
 		if ns == namespace {
 			return bs, nil
 		}
@@ -630,7 +630,7 @@ func (e *EverestServer) validateMonitoringConfigAccess(ctx context.Context, name
 		return nil, fmt.Errorf("failed getting monitoring config %s", name)
 	}
 
-	for _, ns := range mc.Spec.TargetNamespaces {
+	for _, ns := range mc.Spec.AllowedNamespaces {
 		if ns == namespace {
 			return mc, nil
 		}

--- a/client/everest-client.gen.go
+++ b/client/everest-client.gen.go
@@ -88,15 +88,14 @@ const (
 
 // BackupStorage Backup storage information
 type BackupStorage struct {
-	BucketName  string  `json:"bucketName"`
-	Description *string `json:"description,omitempty"`
-	Name        string  `json:"name"`
-	Region      string  `json:"region,omitempty"`
-
-	// TargetNamespaces List of namespaces allowed to use this backup storage
-	TargetNamespaces []string          `json:"targetNamespaces"`
-	Type             BackupStorageType `json:"type"`
-	Url              *string           `json:"url,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this backup storage
+	AllowedNamespaces []string          `json:"allowedNamespaces"`
+	BucketName        string            `json:"bucketName"`
+	Description       *string           `json:"description,omitempty"`
+	Name              string            `json:"name"`
+	Region            string            `json:"region,omitempty"`
+	Type              BackupStorageType `json:"type"`
+	Url               *string           `json:"url,omitempty"`
 }
 
 // BackupStorageType defines model for BackupStorage.Type.
@@ -109,19 +108,19 @@ type BackupStoragesList = []BackupStorage
 type CreateBackupStorageParams struct {
 	AccessKey string `json:"accessKey"`
 
+	// AllowedNamespaces List of namespaces allowed to use this backup storage
+	AllowedNamespaces []string `json:"allowedNamespaces"`
+
 	// BucketName The cloud storage bucket/container name
 	BucketName  string  `json:"bucketName"`
 	Description *string `json:"description,omitempty"`
 
 	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	Name      string `json:"name"`
-	Region    string `json:"region,omitempty"`
-	SecretKey string `json:"secretKey"`
-
-	// TargetNamespaces List of namespaces allowed to use this backup storage
-	TargetNamespaces []string                      `json:"targetNamespaces"`
-	Type             CreateBackupStorageParamsType `json:"type"`
-	Url              *string                       `json:"url,omitempty"`
+	Name      string                        `json:"name"`
+	Region    string                        `json:"region,omitempty"`
+	SecretKey string                        `json:"secretKey"`
+	Type      CreateBackupStorageParamsType `json:"type"`
+	Url       *string                       `json:"url,omitempty"`
 }
 
 // CreateBackupStorageParamsType defines model for CreateBackupStorageParams.Type.
@@ -646,10 +645,10 @@ type MonitoringInstance = MonitoringInstanceBaseWithName
 
 // MonitoringInstanceBase Monitoring instance information
 type MonitoringInstanceBase struct {
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                  `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceBaseType `json:"type,omitempty"`
-	Url              string                     `json:"url,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string                  `json:"allowedNamespaces,omitempty"`
+	Type              MonitoringInstanceBaseType `json:"type,omitempty"`
+	Url               string                     `json:"url,omitempty"`
 }
 
 // MonitoringInstanceBaseType defines model for MonitoringInstanceBase.Type.
@@ -657,13 +656,13 @@ type MonitoringInstanceBaseType string
 
 // MonitoringInstanceBaseWithName defines model for MonitoringInstanceBaseWithName.
 type MonitoringInstanceBaseWithName struct {
-	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	Name string `json:"name,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string `json:"allowedNamespaces,omitempty"`
 
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                          `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceBaseWithNameType `json:"type,omitempty"`
-	Url              string                             `json:"url,omitempty"`
+	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+	Name string                             `json:"name,omitempty"`
+	Type MonitoringInstanceBaseWithNameType `json:"type,omitempty"`
+	Url  string                             `json:"url,omitempty"`
 }
 
 // MonitoringInstanceBaseWithNameType defines model for MonitoringInstanceBaseWithName.Type.
@@ -671,14 +670,14 @@ type MonitoringInstanceBaseWithNameType string
 
 // MonitoringInstanceCreateParams defines model for MonitoringInstanceCreateParams.
 type MonitoringInstanceCreateParams struct {
-	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
-	Name string                     `json:"name,omitempty"`
-	Pmm  *PMMMonitoringInstanceSpec `json:"pmm,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string `json:"allowedNamespaces,omitempty"`
 
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                          `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceCreateParamsType `json:"type,omitempty"`
-	Url              string                             `json:"url,omitempty"`
+	// Name A user defined string name of the storage in the DNS name format https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+	Name string                             `json:"name,omitempty"`
+	Pmm  *PMMMonitoringInstanceSpec         `json:"pmm,omitempty"`
+	Type MonitoringInstanceCreateParamsType `json:"type,omitempty"`
+	Url  string                             `json:"url,omitempty"`
 }
 
 // PMMMonitoringInstanceSpec defines model for .
@@ -698,12 +697,11 @@ type MonitoringInstancePMM struct {
 
 // MonitoringInstanceUpdateParams defines model for MonitoringInstanceUpdateParams.
 type MonitoringInstanceUpdateParams struct {
-	Pmm *PMMMonitoringInstanceSpec `json:"pmm,omitempty"`
-
-	// TargetNamespaces List of namespaces allowed to use this monitoring instance
-	TargetNamespaces *[]string                          `json:"targetNamespaces,omitempty"`
-	Type             MonitoringInstanceUpdateParamsType `json:"type,omitempty"`
-	Url              string                             `json:"url,omitempty"`
+	// AllowedNamespaces List of namespaces allowed to use this monitoring instance
+	AllowedNamespaces *[]string                          `json:"allowedNamespaces,omitempty"`
+	Pmm               *PMMMonitoringInstanceSpec         `json:"pmm,omitempty"`
+	Type              MonitoringInstanceUpdateParamsType `json:"type,omitempty"`
+	Url               string                             `json:"url,omitempty"`
 }
 
 // MonitoringInstanceUpdateParamsType defines model for MonitoringInstanceUpdateParams.Type.
@@ -719,15 +717,15 @@ type NamespaceList = []string
 type UpdateBackupStorageParams struct {
 	AccessKey *string `json:"accessKey,omitempty"`
 
+	// AllowedNamespaces List of namespaces allowed to use this backup storage
+	AllowedNamespaces *[]string `json:"allowedNamespaces,omitempty"`
+
 	// BucketName The cloud storage bucket/container name
 	BucketName  *string `json:"bucketName,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Region      *string `json:"region,omitempty"`
 	SecretKey   *string `json:"secretKey,omitempty"`
-
-	// TargetNamespaces List of namespaces allowed to use this backup storage
-	TargetNamespaces *[]string `json:"targetNamespaces,omitempty"`
-	Url              *string   `json:"url,omitempty"`
+	Url         *string `json:"url,omitempty"`
 }
 
 // Version Everest version info
@@ -5969,139 +5967,139 @@ func ParseVersionInfoResponse(rsp *http.Response) (*VersionInfoResponse, error) 
 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
-	"H4sIAAAAAAAC/+x9+3PbNvbvv4JRvzNNuhJtJ+3Orn/ZsR1v69u69djO3rkb5zYQCUlYkwALgLKVNP/7",
-	"d3AA8AlK1MOOveEvbSyCeByc5wcHh58GIU9SzghTcnD4aSDDGUkw/PMYh7dZeqW4wFOif8BRRBXlDMcX",
-	"gqdEKErk4HCCY0mGg4jIUNBUPx8c2neRNC8jyiZcJBgeDgdp6e1Pg3EW3hL1K05gDLVIyeBwIJWgbDr4",
-	"XOvX85y1vSjI1PvOcHA/mvKR/nEkb2k64qlZ1CjllCkiBodKZOTzcKCwmJqZyRSHZrbVZf5CpUJ8glje",
-	"BuE45nckQoqjTBKkZlSicYUag+GAKpJI76ztD1gIvCj+/jQgLEsGh+8G8vVgOMAfM0EG74fN1zMRe7oF",
-	"avyRUUEi3QeQbFgmvO3Js+RiED7+DwmVHqTCGFLTQI+Zr+l/BJkMDgff7BWctWfZaq/KU571ngiCFak0",
-	"u8ACm543Z8BU90EUEbLBfzgMiZQ/k4V3P6rcWR3jekZQGPMsyocxrfdCzhSmjAjEStTdhKurAx5plhIo",
-	"IhPKiB5VN4cxNBOqGSkJHPz55tcr89iIH5oplcrDvb3bbEwEI4rIgPK9iIdSzzkkqZJ7fE7EnJK7vTsu",
-	"bimbju6omo3M7ss94PS9byImRzEek3gEPwyGA3KPkzSGvbyTo4jMfcveXiYlCQVRbbv1NUlswbdlqqwn",
-	"yW+wwmMsyUmcSaBynVy1BohK4KsrEGfNVfBnZFuFppVERxdnQVPQUvovIqRlgBpnX5zZZ5a7zThz85vm",
-	"dTMisDmVSJBUEEmYApuif8YMmXUF6IoI/SKSM57FEQo5mxOhkCAhnzL6Me9N6i3Xw8RYEakQcBrDMZrj",
-	"OCNDhFmEErxAguh+UcZKPUATGaBzLox5O8yFa0pVcPs3kKyQJ0nGqFqAShB0nCku5F5E5iTek3Q6wiKc",
-	"UUVClQmyh1M6gskyvSgZJNE3gkieiRAkrME6t5RFTVL+TFmk9wk7/QBTLSimf9KLvjy9ukauf0NVQ8Ci",
-	"qSxoqelA2YQI03IieAK9EBaBiMIfYUwJU0hm44QqvUl/ZEQqTeYAnWDGuEJjgrI0wopEATpj6AQnJD7B",
-	"kjw4JTX15EiTzEvLhCis2bgki4WYyJSEK2XjKiVhhXkjIrX8IqmwAgVde8EjIVoTvWUST8gJZxM6zQRW",
-	"fnlpaYkmlMSR1mOgzwiTmdCbi80GgfkIMUMhmFktGsW7EmVsQhVIdSp4lIXQYyZJUFBszHlMMAPTCDqy",
-	"OTdreq2qcJo0JSGd0NDvAxKGxzHxMPOpeWD4eRLjqVmV/tH2LL1zS6nyaLOLs+tLN6/K0p35NKysjSdN",
-	"CCiMORGLpstadk/8vsFxvYkbt2ytK43Q3YzAXhHk5unI4uHXjSim+/WSK0tjjqMzrf/mOL7ycfvbehPE",
-	"smRMhF6LJCFnkURjou4IMa7HmLKYTyUyXZd2SWvZKRENG+dW5LNTWl9HWewz6FfukVlxbO27Y7v8xZIJ",
-	"9+6UbVhnW/dzhV2CR+KIk0sjumWt4jy8mOeytBvmgM7tcr1M4vdJ21bS7KrsBiqjmU94Sn2belltkPef",
-	"c5zdntA8VhwJoj3uwXBgPF3DZ69fediu4KZ2ZsqVhOBsyUpqHNxkgmIrhs6Hy3vz8XnVl1xDQLTpugJL",
-	"7rdT5lnOSBhcNmRtv1b4Y86VVAKn2j3AiJE7ZL25Nl5vGe249LQuTNbV0Lul2ZiAG/FIsgQmEVZqzEbg",
-	"Y8wUq5nHbGA1cwPoFs5ttMua0JjsRVSQUHGxCDZiExjYu7Fj6y2Y1fjJ8ea40chHkDfHbk/d1Jtb0STJ",
-	"SksKRnNE2ahiNKsas7HJ2gX0smo+87fXJ5pLLb9Ap+BI6qhbxz6pMhuaYHWIbgav9vf/Oto/GO2/uj74",
-	"4XD/+8P9H/59M/DusovQIjLBWax1BcymDiFcL9J8MvoVTUa3ugBE2wR49mUTRHhivM+Nbf3s2WjCppQR",
-	"n8rWv7t5uEgLmeYr3CqzBc0+jcvo+rRd1ffLo7XTmIbYq67Nk6aetn3nr3r0c0IZTTQlD3y6ugiAPKPa",
-	"RwhbvymPZmIKAYgWd4LDWW0aATqbIB2MSKKGjZd0Z/ohTVIuQXPXiJpm4KuzxW+TweG7T81JN6L593XW",
-	"Orl462il/5lPwaqJBNBY0Ao6Ih0cDv7/i5ubv/w5evmPFy/e7Y/+/v4vL25uAvjXdy//8fLP/K+/vHz5",
-	"4sW7n89/vL44fU9f/vmOZcmt+evPF+/I6fvu/bx8+Y//AWCmAItGWtC5GNl1OUwmIQkXi62Jcg7dOLqY",
-	"Tp83aXxyLgs8veZ7OOiuIpXO3VuuTcMYS4+EnOifXYd5T/CjBbscgpMSIanUThea8zhLoBn1GgRJP5Kt",
-	"9/qKfsxXqjvMA7DWeTyXDS9beiBVu5/3aYnBsdtvwTxnatL7UJOCSzUVRP4R6z9kEo39yKIk4gqAQel3",
-	"G95WG3i9eHiMLKDtoCOAEcwjL5gyb4P5HMZXXaRrvspxKtBYaOcjbMIZVdzsSH3w8/xZrmOKX5bLV9HQ",
-	"mE4/Pc89repExajeFzq5DPzmtoPlcw591YhZOMcJdzFi4NMcNPGrDppICKeLBUjjAtnBh/lBBGXgiATu",
-	"kXl5aIJXbU/B+R4vDHaYn44E6Iaha/2TjkcZwnE6wxbBwixyKt/iII753iwYTmjoaHAUu0gYTQhWmSBo",
-	"ihUp+jb96UGSJFM6hArQmQIUjLN4gcaayw3qlc8MooMWvOCyvEgkyIQIwvRecKY5WmkTxtAFj640SSqt",
-	"ZZP+S4LqJJMKJViFswoHVYZJeRR4SO/E94JHOaxUJoXeD6BCgm8BV8CqYCE8xzQGSIAySSOCcGnLVgop",
-	"LGhlbFvTpZrNRglOR7dkIcu9NFvZbhKc6k6Nz9Z+Nri2mXomLlf9UAs8V/Pj2AJFCb7XfjXCCc8YYGIh",
-	"T9JMFW5yfvTlBd+XnRFWtOVeghmeklHe7aiQo72BhxPcucDXvm2X7nyktnEmIFq6cU7iIJTJ+6ES8YQq",
-	"GxiX5XaIKMCIOt4F58+yDJ0Y4acSkXsdHFEVL1xUSaIh4mpGxB2VEIZjpqOiGJxw2PqRswBwxhQUMwnN",
-	"aQ+5DwmJ7GCPymXdgu4Ua03oQ3zAYlVgUql4ak+5HC7mOXcQ/H7h6U//nOMl8Eclcq9GpNoUptpMCIqV",
-	"tz26o3GsLRdO05ja7dZ9T+mcMOtXBehIc05iznBQiK2/L4myh4Blk6A4cIvgsXHN7u1ZqDlmdpBXjj+E",
-	"bWdY3TAHs6aVkAO51zG4BxSB36udmbYrHDlqkclLzKY+z+rsovzcDeAOFc4uHIYpzPMXJ2dvLvXGwWgv",
-	"QUa0SnVUmwieVPdWgTWmEjFe9tXa3Y3KjEpHs3oyOIoEkVJPlKHKVBAX6I6qGc8UoLkqwfJ2CRjWTF8o",
-	"wDF3LL4UILPU128Pwbcak+I8nYucn0rBTKnf/GkX9GwzJMowyZcGoiqz6HGoHof6YjjUagjC8GoNgUg4",
-	"m3K98Bk2ts7aPAtGTMc8YyERXWHw6vkWIODe81+FVSZXp2BAs8pxKR9LIubrZWGEis7JVRtOd1R+XAfX",
-	"jNvA8nOWFwDPQKD50qd9Z1wqfwj4k33iRnAtS2kCbhCrboXWMP5sgYRI6V3MuXlg/D8lcDlTF+GxNh9e",
-	"l6d0PsSF8jg8XKjifEioLrPucHIrCI4WPgWMo0VT5UNrHSLLjufCFtlshyoVVzguG5XufbdwsGXZnI3g",
-	"Lxu9t1K9m3NbY/TjlnQdb7NuiX72KLVP9+vT/b66dD+bXbBu0p95LXhKSQ95isGK5ILykFzQKdWyUw8I",
-	"YTKb5UBU57GFG+BosL4z0LY7IU/SmCgfVHDiHuU2ghojbdLg/sPH6A5LlPcQlO2FlgxIm/Dti8nR9A1p",
-	"HpQHlAonqeOBLJVKEJzYXf9WmnRPm7jWbfCISEVZS/bpm+Khm8Qki2NPcoyX4aY49WzijziViEZahieQ",
-	"8zWxwTIGSD/VW6kF3jhYeZpkzKf+FFDYY7/BzdnYbX9+WwSrDswL83+/uQ12N2Y6MDFcVzCnI1ZbA1xn",
-	"oa8qOmHCcCpB5TfksqQBejv9oHY6B3I63Yjye2keYKY3/49i/jtI8YkgoKZw3NyPIhK39G3IW4qlvOMC",
-	"9rK4NCU4V4OWQ3wXIK5q3WHqnVTPzpROr22euLbp9cxT1jMX3tTblnRbQWJwCmG4xv0aLGJKpHpjXaJC",
-	"k7zaf/V6dPBq9Prg+tXrwx/+fvjD3//d2Un0O3KURTTUwlR14VKqBHhrNWcOT5Tbf5uVrP1lhW8J8/p1",
-	"Rk6r6dCNmZlGO11uhw27NLnUKxWsbdcNZLEJ2j3K0qMsXx/KYiVlbZjFvhf47h1sd1HGiOPya2D91Zj+",
-	"akx/NWZnV2PWAijLWqKMSZY2dDUflrTEDnFJp8w2ACZb9VkFmezmtZUOA5vJ/X7QrDTzSg5KPt2aVtzF",
-	"eZUds1PEWmq7G7TMOV29w/W0A1jncfdx7FOMY09b7jRWn68Ig0xaSB/+9OHPVxT+GMmAsMeQXf/L5HTX",
-	"rgC3VJEhkeX9qmpdI/2zeQkZvD6pMIuKu0UyS1MuHPBUmpcM0CWdzhRi/A5R9a00t23S+xBkAPKiAvQT",
-	"vyNzm55uE4JSOUTpFBphtjAJ6DY+Wu24tV4MW+WiWYKv45qdttHf3Z8p74D3Hpx2oERWkY7S7Zu5a8Qn",
-	"jXvfhWVsC0KXXa5onmBDX4WjVM4Cs75S6wyCnCDotPbIbWnt3WHxg8kx1LzEeSwRTUyxPjXzeLqCKhri",
-	"crW0EioIb/6E5czL5fD0wkawXqc3k/4qbG3XmHwX93tyPwK58xsWrTeH+l14+F1o/qCX0m/L09oWXxO9",
-	"DKy4KLnNSybhcwPaUQC7HZQhjG7/JsuXhLZCBMy4y5GAos12CIDzXvpQ42kG/jam7AP+pxTwnwrBPVA4",
-	"/KyJmnImSbOqQisQ6Rvj5zyzxmI/Z2zClybgODBPU9FT+AAeXtt4x6MD4RACSqhAFd3KQfK7wTR9NRgO",
-	"pulrHW50ja9q0Up5Dr4R33chw2X7xTQPLcoS2RK2QJJS/arZOY1jWl6iuQRRrtw8OBxklKm/fg+YPZW3",
-	"V/Y+Rbc3zEWr44UinYdpsEm5jrTJmiou5x3l6/s8HIQ4xSFVi//StZ645TU4zj0Ylvbbx2ZFLZMzpkN+",
-	"c56J49jeq1umqpvvHmNJ/i9VMzhB8dy4K1VmsW/UPhnQiPFN4WxPmWtbaPG9dw16HssLw/iHr7LIzqqM",
-	"J82Btyo1niZJ85Cte211W4o8oewXwqbaQT3YtLPPnViqwhZbshdc7exSW+UpF9F/GNJvIG8dNs/cQih9",
-	"nGEnumG47usX5+cdV2hrXj+IYtGzaJgSLY6NH3FK7dcLdrHZw0o68caCL03t/x0xnMcyXZyfN4l2lZJw",
-	"0FFVvAUveTfc9qBcZtz5Cpd5F7Ted1M85thjD3JubfS90pQY+n71311p+0DJs/jySOunRBry1QpknM6J",
-	"IFI55MIfOk2yOD7hSULVNkonFVxPx5/C272beRuOtYb6KhuB8rSK3oflRfv8ZcohNMcpTXA40zy4CNLb",
-	"qf5BBjqaDuYHgWaBc2Ki6iZz6CelUlAuBDcIllwwNSOKhqUiUFAgbobnZIgoC+Ms0orIVOzDLEJzLCjP",
-	"ZH6p3DgfAToqYI4EL6ADczbHGbhAn36Dlno6Q+Qm9tlb6UdRlnkE1D2B/m19PTopl45UUKo/oQpxVru1",
-	"D/yOBFGZYCQyMFaRUp5/ygJO5QSaYe1GC4PrFodnJhfOQD1UIp7iPzKSI2Jjkn8hg0oJD8wxo4VoHLBW",
-	"QnP0FphzQJBSwBBN2XlBydxUNmDkHmq5AJ6XH+PldD8xVDEF1kPOXKFT6EtPywJCKZeSQvm9SXml1Q9W",
-	"6HWHM8ymJEJcGBKoGWYIowm5QwllmSYXbK52EUhkSOK23sGVpv6To7a5t5rJvDxUvpOGlK7slLmmGeLY",
-	"UcpS2uzlhAqpcthniDIWEynRgmdmPoKEhOakVPyWMIOgYYYIQEYWGWqpi5mYUqRniiQnPGMeULjZplkd",
-	"QmZjqbdbPwOWs7OH7bib0XBWlOAB6XIXT932uwVCGZ/8TcdCzhZFCFx8vUmG1pLEkA4L9TEJa9SssDN3",
-	"k5IoY7eM3zHgXkNe3Y3biphMFMoYiBSL8vpvUQZuiSSC4ph+LKqM5ROlxaVk9IJQ4P8xCbG2RFSZElUK",
-	"hbOM6QBGz989VbZkp8GepW30sliPvfHBuOHL+prMQvLiYxutxAGxPI4AhMUMzQ+Cgx9QxF1JpdIYhve1",
-	"1md6G/UibKzn55TviFRUe29s+l2lRrEW3FjvH0ziBADeHKnX4woCirStb8WdPoRzJv0HucehCmpVRP76",
-	"/WBZEapW+31lollT06+4S12okW9l6ZzA6gB3KlE5MTGnZa5wa2hXqjhc3BEJZfaSu1VvRrKtRgrQv0Af",
-	"gIEaE6TshXWca+JSl5ANAhoKZSzhERQeBDfIKRcz8wBd8DQzl5yglCxBciEVSQJ0SXA00ibswWFzHeBn",
-	"QhAWLka2XN4Is2iUq/Nw4a2ZTeLJL5TdNjfMPTFHFG8vf6mfTOT70mn9N+yGvTm9uDw9Obo+fYMKsNhI",
-	"GdQw1FYcT3GjBiBDB8Grfc3BBEtSUzdUojTGjBmrCXV7Ej4n7rUD91rQ7eJUJ3fJZOOcaJ3TVjgHHuoV",
-	"zWlErCfQLGEEBRWp7Q9NMI0zUXGaQiw1iTQ/J1msaBoTY4lMGTbCQi29RJjyDTVvWNPHH6QY0uWaJj9b",
-	"wsrYb1NlEvYARhtqCdHxAewwVRL9n6vffq2rvnM4ewKLhCJulGXKpZrQ+6L+34QLxIgEqVOG04n2/XSs",
-	"YBb1kQg+oiwi91pg0T/1XM3BFk5Tgss+BTcAEdBRdwA1SfXkJYoyyKyfmLdneK7JWaNhgH6zrjfw56k5",
-	"RJGHNwyhG0BVbgZoVGK2/EerSI3IFSWKzYtgTN7tvw869GBcEjP5vHiy7eJmsFbJrCM0yxLMRoLgCBy8",
-	"0uO8chMumRggQoDK1aitE2oFHTTjyNTgxFC1yntmDuWvpPf4GVkpWntSZ1b1554ySVK1qFSprIhT7l/v",
-	"XMzfEIVpLH+fv2qTddvCHuZaNztHJlAhlUbCzo/+n7O1Tl0aR1pxpzDKr3u0RsnD09J8CdQvhBqjq3Jk",
-	"lZ/830HV81zocv9GElW4DGAa6ZTB/SIjPOZTX8Z9Kcp+O5zaXbOBMpJ57yY8sv4HljJLrH7BbFG0cvwG",
-	"m6v13hzHNBpqHyRjUQGGe2I8kHK/djsxGsAIlVVILhizW4Wl5CEFk3VHlVmQIZojptHFAfpVK7I4rjw1",
-	"2sjtlemTRFbzVCq0L4PO1jY1HmRlKrivdJqmAjwqkbqu7X0ksBF5ea1B92RsPap+soNB0W8MSZ4QZLKC",
-	"qKN5RCcTIoq0BhvUkKgY4mfKoi+dpcBa4UE4r9maPujFXRHRGLVD2TS23ZsY0aWVWdwmetmiuZVYHE0U",
-	"fHCD6+U0C/1OynW380pSlJU+rzjhtohivl9O9sEjU4JqW36ld9S6LyZRxaAn5aQU0D8K3xLz4QWICBRB",
-	"2Hzzc2Tzu7nMO1JV65X3OeN3KOYMSmTfYaryWeJbl1pT7z7oVjIxox7mf3v2pr6bQes25fvdtlV1/vWf",
-	"6mWSiNE0oxHZy2MqIb/JqI8rtzSDS+yfWZqBaqzBho9W4DjOjQf7VrkWBtFy6FOfzvbQ6Wwhj3xhSjad",
-	"Gs350/X1hdsb3daKGHUA7RDtI5rXg+4oI9bQ7tAGlvywPqduxzl1W0QU5cqwAGiT1tu21ey9rdkiP7TY",
-	"KgC5my1qM4dP8pjo7GbwT+MH3gzsQreITNCR89TDGAuDf2FmxM9SEcRvnGmFSQzMyedECO1lUuWl6Iry",
-	"vXaTil1Bv8FZyiG6GVxlcNCpY1FRXumDs6P2JgCcspPvkoStjZU3rfIbdJSpmUH99U837CiOy+KH3NHh",
-	"0cWZK5KOPuiXuLDQxSE6JlgQgW6y/f3XIQD/8E/yAc0g6jXeGEYQn9iTAcpQGmPKRorcKwAQrqESs35m",
-	"LTofW6h9vLCHFx+ImU2oYttUqxv1wXoC8Icr6ayfAoYiqI7MaH78I0NBCAtuICGGKiggdEFEyBnOV2tE",
-	"qXRSeDg4CPaDfZtqz3BKB4eD18F+8MrWsgAu2jPHvCN7zAu/TYlqPzU2XyM2MGr1iFhvbM54Z5F9p3KS",
-	"LyHRxcSyMNSr/X13gkfM+Ql8SMRs7d5/rIzbta1QItWRIPMA+KhuB0EKJllcSImm0fc7nInJQvYM/pbJ",
-	"luF/eIzhz5wnYwEIYhsOBzJLEiwWnfdZ4als1EmBlKSU+y5HmBwt+z3nanfOP9MC9d13DpP77jtA5T58",
-	"+KD/90n/p8DotDaTrx3P3gyG7rHWIu5x6ecih8M8NH8flFrkOSCmgfnz91v9d94mz7uwI8CftTYmbcM0",
-	"INkoJEwJHI8Obga6xed8ScvXhj9mgixdHrRYssI8AWXJIm3/v+MQQOXfzfity621LtZdrKqhAMy2VwRz",
-	"kH9265ibEvo74XnPSDZtyCMH16V6RxUmtEcKruBxOSHDZnk8jvbqFdf6imu1ilmitz4PG5Zw75MWiM9G",
-	"l8XEWwoJfjcm2iEmzbypqkiYd+oiUUpPO3zn/QijVcnNrCwoxYjVzOWFHroP/Fd5d1jag7r79b7B19/7",
-	"Asie/5bxXzdmaDecXq/rR6LWY68fiXrqvNXrzCfDsx3Ya4mnh1XorcQnFMWxyz92sEHLCAEyCb+2Kke1",
-	"qTmPChpM7skRfhp8vnu/pj0duptfA0SRAfqtjbr5qaCDqnqv5zlJ8HrStsIDsnczRw55WWqS3EVOOA+G",
-	"w9/yd/3NJ7oxat789Jks/5XaB+Q7/4A9/21sQbbgBseRt3+Tlg+L64gjd51lPWDKc5/Rj055rsM8JNu1",
-	"3b7pGW8nOFXLtjsGSzyb3Q5ZHfm6K46NwEJK9EEz/IcinTa4YcdYksjle7nn5pg4JfDNRnRLFgZhrubS",
-	"M0IiWenrKgtnCMshohPT1SFKk+SDzXD+oP8NnZXftHkqkcOwK2MErSiN52bXw7g0K25wtvg15+2b8eVA",
-	"G99tuF6Ut0Ju2oVupSS3mY5NkZxz7614H5zjlZ3O8UjL7fuvHNj53sz1YYf3aRXGFZrwjEVPH17yc+gq",
-	"e9cRaUo6sP+PRG3H++ePyPu93u8FqwsGlmwkVS1wmAFwNrAs5sUnbVkewzes1Fto8Q2TVb7hF8G2eiXx",
-	"36Mk1pDi1T4qqxRnaLXGOI7LNRoSzPDUpBbZnB8volEpFPNgvF0t8NGZrRuKd/UaaxQzvjz8+/Oeq5U5",
-	"csCl/W4QFLtZnofS8lnaltjY/23UNRRxPul29esef3Ed3PIhWL/qbaHjlw/NO6+iTQG/2j94/Mm4L2pb",
-	"tWzm8erx53FkP97UwxQemKJddzjdH3np/H4TXbYpeLFCr5l3nqZeGy4bsYX4kHSvdQ34DvY24blNP3/n",
-	"kuve559Z8y3cZSI+gwB0zYs8PSi5G7xlbYFvAVsu4faNXE9kfySql9dnKq9beyO9WBqx7Cg5uzTE7hN8",
-	"m0QV9t1uYcVl3vhriCvyL+Z1DCzcR1CfWmSxZB1fILRYMpvHjS2WTKQPLtYJLgoV0qLUHKU302rbxhdt",
-	"Gs4bYDwVDbeex+K+1ruVy3JZUV99jNELfWfBWin3G0UZbYLbDDN6qX2+kcYG3kkvnV1CjbXEM8284pnG",
-	"OFzXrpqTqF5CH0FCn0cIZM+2+xBo/RBoksW9wisrvG4KaZdxyHp5/XWJ8Cf11/hBPg1A5XFEsb9OsLvr",
-	"BD5ua+H9LqUv6t11AwW/EjSwsw18avDfEzF63axdvHhg1K+H+7aE+5aqmHXs6qa43kot5QX2nlfksV3E",
-	"0UN4vSAvh/DWEurO9zFWSmYTuevF8jlgdL3c7eLWxppCtwYkt1LwvJhcL3tPHH3bLOR4AnBbry92hW09",
-	"tPe9V7qQsDHIhVwnHbCu47xpr3ueSRZgj9g9HGJXEp0dZgTm0h0KAp9hwLFcWS6pXemgcjerffqTSute",
-	"zJ+8mBcb1ov5Qzj6NfnZrQFPqRIrZfuCU6ZGlI2uaUKQIHGujOy3NbYM4y/0JHpZfwayDjvVS/nGUr6t",
-	"JO1W+MuZ/5u773kvHfz3y6JtL+3PJbmu9+Af0IMvSc9O8k4Im1LWQaSL7+bnU3KvLpPj07zNf3/KiVlr",
-	"z/3bc/9SZquzvSH7euxeOg1eN0o1PSzzUk9di+dgsvLlPBdbY6nbS9guQ8ecC1qFq+WEyFsIaJWsVM+H",
-	"vnJxebhznXZJedrHOr2E77Qs1xpCri1o8S3VlRXvcYpDqhZQ37ww2XkHW1W8vyx90vXxyt4Xo/bct3nt",
-	"+835oln7fl58C7mVGd03H49xeEtY5L6HDJ/wbDCb/YDyQ39RwX3DefNacEtXBd2avTDWMhPx4HCwNz8Y",
-	"aLNi6Vgnlu5yoWaUTXMsyX5Ss5AEVLomYA2b3o2mfWzvzClyT1d1IGqjbougstarsxxbzBWVICf/nPP7",
-	"NNuMUhxM+wdxFVHWGOO4/mkT23P1yyaf33/+3wAAAP//6jMNuFv8AAA=",
+	"H4sIAAAAAAAC/+x9e3PbNvboV8Gov5kmXYm2k3Zn1//s2I639W3demxn79yNcxuIhCSsSYAFQNlKmu/+",
+	"GxwAfIIS9bBjb/hPYpEgHud9Dg4OPg1CnqScEabk4PDTQIYzkmD48xiHt1l6pbjAU6If4CiiinKG4wvB",
+	"UyIUJXJwOMGxJMNBRGQoaKrfDw7tt0iajxFlEy4SDC+Hg7T09acBjmN+R6JfcUJkikPzsNrbL1QqxCeI",
+	"5W2Q/QopjjJJkJpRicaVQQfDAVUkge7UIiWDw4FUgrLp4PPQPcBC4IX+Pc7CW6L0HLzNK9PxvGdtHwoy",
+	"9X4zHNyPpnykH47kLU1HPDWQHaWcMkXE4FCJjOQz/TQgLEsGh+8G8vVgOMAfM0EG74fNATMReyYCM/kj",
+	"o4JEug+YbmXRtqehBxvFKHz8HxIqPUqFNKRGjx40B/f/CDIZHA6+2Stoa88S1l6VqjyoOBEEK1JpdoEF",
+	"Nj1vToKp7oMoImSTAsOQSPkzWXhR+ATpszr69YygMOZZlK/VtN4LOVOYMiIQK+F4E7quDniklyRQRCaU",
+	"ET2qbg5jaCCoGSnxPfx88+uVeW2kAJoplcrDvb3bbEwEI4rIgPK9iIdSzzkkqZJ7fE7EnJK7vTsubimb",
+	"ju6omo0MCco9gPTeNxGToxiPSTyCB4PhgNzjJI0BdndyFJG5b9nbc6UkoSCqjWQei2cLwi3PaE1efoMV",
+	"HmNJTuJMwhLr6K41QFQCUq+AoTVK4WdkW4WmlURHF2dBk9VS+i8ipIV+jawuzuw7S1pmnLl5pgnNjAg0",
+	"RiUSJBVEEqZAr+jHmCGzrgBdEaE/RHLGszhCIWdzIhQSJORTRj/mvUnNoXqYGCsiFQI0MxyjOY4zMkSY",
+	"RSjBCySI7hdlrNQDNJEBOufCqLjDnLKnVAW3fwOyDnmSZIyqBfCjoONMcSH3IjIn8Z6k0xEW4YwqEqpM",
+	"kD2c0hFMlulFySCJvhFE8kyEQN4N2rmlLGqC8mfKIo0n7JgTplpATD/Si748vbpGrn8DVQPAoqksYKnh",
+	"QNmECNNyIngCvRAWAX/AjzCmhCkks3FClUbSHxmRSoM5QCeYMa7QmKAsjbAiUYDOGDrBCYlPsCQPDkkN",
+	"PTnSIPPCMiEKazIuMWPBJjIl4UreuEpJWCHeiEjNwEgqrEA61j4I/ObQWybxhJxwNqHTTGDl55eWlmhC",
+	"SRxpGQ3qhzCZCY1cbBAEsjvEDIWgaDVrFN9KlLEJVcDVqeBRFkKPmSRBAbEx5zHBDPQSqLTm3KzytaLC",
+	"Kb6UhHRCQ78dSBgex8RDzKfmhaHnSYynZlX6oe1ZeueWUuWRZhdn15duXpWlO91lSFlrLpoQEBhzIhaN",
+	"6Y7LBopfMR/Xm7hxy6qy0gjdzQjgiiA3TwcWD71uBDHdrxdcWRpzHJ1p+TfH8ZWP2t/WmyCWJWMi9Fok",
+	"CTmLJBoTdUeI0ftjymI+lch0XcKSlrJTIhpKzq3Ip6e0vI6y2Gd/XblXZsWxNccc2eUfliwuL6ZswzrZ",
+	"uscVcgkeiSJOLg3rlqWKM69invPSbogDOrfL9RKJ3yBsW0mzq7INpoxkPuEp9SH1stog7z+nOIue0LxW",
+	"HAmizd3BcGDMTENnr195yK6gpnZiyoWE4GzJSmoU3CSCAhVDZ8TlvfnovGr6r8EgWnVdgSb36ynzLick",
+	"DCYbsrpfC/wx50oqgVNtHmDEyB2y1lwbrbeMdlx6W2cma2pobGkyJmBGPBIvgUqElRq1EfgIM8Vq5lEb",
+	"WM3cALqFMxvtsiY0JnsRFSRUXCyCjcgEBvYidmytBbMaPzjeHDca+QDy5tjh1E29iYomSFZqUlCaI8pG",
+	"FaVZlZgNJGsT0Euq+czfXp9oKrX0Ap2CIaldXu38pMogNMHqEN0MXu3v/3W0fzDaf3V98MPh/veH+z/8",
+	"+2bgxbJz0SIywVmsZQXMph5EuF6k+WT0JxqMbnUBsLbx8OzHxonwOHmfG2j97EE0YVPKiE9k6+duHs7T",
+	"Qqb5CrPKoKDZpzEZXZ+2qzq+PFI7jWmIveLavGnKadt3/qlHPieU0URD8sAnqwsHyDOqfYWwtZtybyam",
+	"4IBodic4nNWmEaCzCdLOiCRq2PhId6Zf0iTlEiR3DahpBrY6W/w2GRy++9ScdMOdf18nrZOLtw5W+s98",
+	"ClZMJBCRBamgPdLB4eD/v7i5+cufo5f/ePHi3f7o7+//8uLmJoC/vnv5j5d/5r/+8vLlixfvfj7/8fri",
+	"9D19+ec7liW35tefL96R0/fd+3n58h//A1GRIlIz0ozOxciuywVEEpJwsdgaKOfQjYOL6fR5g8bH57KI",
+	"qddsDxc3q3ClM/eWS9MwxtLDISf6sesw7wke2tiki+CkREgqtdGF5jzOEmhGvQpB0o9ka1xf0Y/5SnWH",
+	"uQPWOo/ngvCypgdQtdt5n5YoHIt+G81zqia9DzUouFRTQeQfsf4hk2jsDy1KIq4gMij9ZsPbagOvFQ+v",
+	"kY0mu9ARhBHMK28wZd4W5nMxvuoiXfNVhlMRPId2PsAmnFHFDUbqg5/n73IZUzxZzl9FQ6M6/fA897Sq",
+	"AxWjel/o5DLwq9sOms8Z9FUlZsM5jrmLEQOf5KCJX3TQRII7XSxAGhPIDj7MdwEoA0MkcK/Mx0PjvGp9",
+	"Csb3eGFih/nWRIBuGLrWj7Q/yhCO0xm2ESzMIifybRzEEd+bBcMJDR0MjmLnCaMJwSoTBE2xIkXfpj89",
+	"SJJkSrtQATpTEAXjLF6gsaZyE/XKZwbeQUu84LK8SCTIhAjCNC440xSttApj6IJHVxokldayCf8lTnWS",
+	"SYUSrMJZhYIqw6Q8Cjygd+x7waM8rFQGhcYHQCHBtxBXwKogITzHNIaQAGWSRgThEspWMiksaKVvW5Ol",
+	"msxGCU5Ht2Qhy700W9luEpzqTo3N1r47uLaaeiYmV30PEixX83BsA0UJvtd2NcIJzxjExEKepJkqzOR8",
+	"p9IbfF+2QVeRlnsJZnhKRnm3o4KP9gYeSnD7Al872i7d/kgNccYhWoo4x3HgyuT9UIl4QpV1jMt8O0QU",
+	"woja3wXjz5IMnRjmpxKRe+0cURUvnFdJoiHiakbEHZXghmOmvaIYjHBA/chpANhjCoqZhGa3h9yHhER2",
+	"sEelsm5Od4q1JPRFfEBjVcKkUvHU7nK5uJhn30Hw+4WnP/04j5fAj4rnXvVItSpMtZoQFCtve3RH41hr",
+	"LpymMbXo1n1P6Zwwa1cF6EhTTmL2cFCIrb0vibKbgGWVoDhQi+CxMc3u7V6o2Wd2Ia88/hC27WF1izmY",
+	"Na0MOZB77YN7giLwvNqZabvCkKM2MnmJ2dRnWZ1dlN+7AdymwtmFi2EK8/7FydmbS404GO0l8IgWqQ5q",
+	"E8GTKm4VaGMqEeNlW63d3KjMqLQ1qyeDo0gQKfVEGapMBXGB7qia8UxBNFclWN4uCYYV2SbN4JjbFl8a",
+	"ILPQ118PwbYak2I/nYucnkrOTKnf/G2X6NlmkShDJF86EFWZRR+H6uNQXywOtToEYWi1FoFIOJtyvfAZ",
+	"NrrO6jwbjJiOecZCIrqGwav7WxAB9+7/KqwyuToFA5pVtkv5WBIxXy8LI1R0Tq7a4nRH5df14JoxG1i+",
+	"z/ICwjPgaL70Sd8Zl8rvAv5k37gRXMtSmoAbxIpboSWMP1sgIVJ6F3NuXhj7TwlcztZFeKzVh9fkKe0P",
+	"caE8Bg8XqtgfEqrLrDvs3AqCo4VPAONo0RT50Fq7yLLjvrCNbLaHKhVXOC4rle59t1CwJdmcjOCX9d5b",
+	"od7NuK0R+nFLuo63WbdEP7uV2qf79el+X126n80uWDfpz3wWPKWkhzzFYEVyQXlILuiUat6pO4Qwmc1y",
+	"IKrz2MIMcDBY3xhow07IkzQmyhcqOHGvch1BjZI2aXD/4WN0hyXKewjK+kJzBqRN+PBicjR9Q5oX5QGl",
+	"wknqaCBLpRIEJxbr30qT7mkT17oNHhGpKGvJPn1TvHSTmGRx7EmO8RLcFKceJP6IU4lopHl4AjlfE+ss",
+	"YwjppxqVmuGNgZWnScZ86k8BBRz7FW5Oxg79+XkRrDoQL8z//eY62J2Z6UDEcLrE7I5YaQ3hOhv6qkYn",
+	"jBtOJYj8Bl+WJECvpx9UT+eBnE5novxWmicw06v/R1H/Hbj4RBAQUzhu4qPwxC18G/yWYinvuABcFieW",
+	"BOdq0LKJ7xzEVa07TL2T6NmZ0OmlzROXNr2cecpy5sKbetuSbitIDEYhDNc4X4NFTIlUb6xJVEiSV/uv",
+	"Xo8OXo1eH1y/en34w98Pf/j7vzsbiX5DjrKIhpqZqiZcSpUAa61mzOGJcvi3WcnaXlb4ljCvXWf4tJoO",
+	"3ZiZabTT5XZA2KXJpV4pYG27bkEWm6DdR1n6KMvXF2WxnLJ2mMV+F/jOHWx3UMaw4/JjYP3RmP5oTH80",
+	"ZmdHY9YKUJalRDkmWULoajosSYkdxiWdMNsgMNkqzyqRyW5WW2kzsJnc7w+alWZeyUHJp1uTirvYr7Jj",
+	"dvJYS213Ey1zRldvcD1tB9ZZ3L0f+xT92NOWM43V9yvcIJMW0rs/vfvzFbk/hjPA7TFg13+ZnO7aEeCg",
+	"raiepf2qaF0j/bN5CBmsPqkwi4qzRTJLUy5c4Kk0LxmgSzqdKcT4HaLqW2lO26T3IfAA5EUF6Cd+R+Y2",
+	"Pd0mBKVyiNIpNMJsYRLQrX+02nBrPRi2ykSzAF/HNDttg787P1PGgPccnDagRFbhjtLpm7lrxCeNc9+F",
+	"ZmxzQpcdrmjuYENfhaFUzgKztlLrDIIcIOi09sqhtPbtsHhgcgw1LXEeS0QTU65PzTyWrqCKhrhcLq0U",
+	"FYQvf8Jy5qVyeHthPViv0ZtJfxm2tmNMvoP7PbgfAdz5CYvWk0M9Fh4eC80Heik9Wp4WWnxN9DKw4qJk",
+	"Ni+ZhM8MaI8CWHRQhjC6/ZssHxLaKiJgxl0eCSjabBcBcNZL72o8Tcff+pS9w/+UHP5TIbgnFA6PNVBT",
+	"ziRpVlVoDUT6xvg5z6yxsZ8zNuFLE3BcME9D0VP4AF5eW3/HIwNhEwJKqEAV3cpG8rvBNH01GA6m6Wvt",
+	"bnT1r2reSnkOvhHfdwHDZfvBNA8syhzZ4rZAklL9qNk5jWNaXqI5BFEumzw4HGSUqb9+DzF7Km+v7HmK",
+	"bl+Yg1bHC0U6D9Mgk3IRZ5M1VRzOO8rX93k4CHGKQ6oW/6VrPXHLa1CcezEs4dtHZkUtkzOmXX6zn4nj",
+	"2J6rWyaqm98eY0n+L1Uz2EHxnLgrVWaxX9SuDWj4+KZytq/Ota20+N67CD2R5ZVh/OM/1LUFSXPktWrD",
+	"16uNp0nS3GbrXtrcViNPKPuFsKk2UQ827exzJ6KqEMaWBAaHO7tUV3nKNewfBvQbcFwH5JlzCKULGnYi",
+	"HYbrfn5xft5xhbbq9cOIFj2NhjbR/Nh4iFNqbw/YBbaHlYzijTlfmvL/O6I4j3K6OD9vAu0qJeGgo6x4",
+	"C4bybsjtQcnMWPQVMvMuaL3LUzwa2aMQcmpt9L1Slxj49pevPIXLV9puKVl5/UjrfSINBmsNZpzOiSBS",
+	"ueiF332aZHF8wpOEqm2kTiq4no4/jbd7N/O2WNYa8qusBsrTKnoflhfts5kpB/ccpzTB4UzjfxGkt1P9",
+	"QAbaow7mB4Em2XNiPOsmMes3pXJQzg03USy5YGpGFA1LhaCgSNwMz8kQURbGWaQlkanah1mE5lhQnsn8",
+	"YLkxPwJ0VIQ6EryADsz+HGdgBH36DVrq6QyRm9hnb7UfRVnmYQ73Bvq3NfbopFw+UkG5/oQqxFnt5D7w",
+	"JxJEZYKRyISyirTy/DoL2JkTaIa1IS1MbLfYQDP5cCbcQyXiKf4jI3lUbEzyWzKolPDCbDXaMI0LrpUi",
+	"OhoFZi8QpArEEU3peUHJ3FQ3YOQe6rlATC/fysvhfmKgYoqsh5y5YqfQl56WDQqlXEoKJfgm5ZVWL63Q",
+	"6w5nmE1JhLgwIFAzzBBGE3KHEsoyDS5ArrYRSGRA4lDvQpamBpSDtjm7msm8RFSOSQNKV3rKHNUMcewg",
+	"ZSFtcDmhQqo89DNEGYuJlGjBMzMfQUJCc1AqfkuYiaJhhgiEjWx0qKU2ZmLKkZ4pkpzwjHkCw802zQoR",
+	"MhtLjW79DkjOzh7QcTej4awowwPc5Q6fOvS7BUIpn/xLR0JOD0QIjHyNJANrSWJIiYUamYQ16lbYmbtJ",
+	"SZSxW8bvGFCvAa/uxqEiJhOFMgYsxaK8BlyUgV0iiaA4ph+LSmP5RGlxMBm9IBTof0xCrDUnVaZMlULh",
+	"LGPahdHzd2+VLdtp4s/SNnpZrMee+mDc0GV9TWYheQGyjVbigrE8jiAQixmaHwQHP6CIu7JKpTEM7Wup",
+	"zzQa9SKst+enlO+IVFSbb2z6XaVOsWbcWOMPJnECQd48Wq/HFQQEaVvfijt5CHtN+ge5x6EKapVE/vr9",
+	"YFkhqlb9fWX8WVPXrzhPXYiRb2Vpr8DKALczUdk1MTtmrnhraFeqOBzeEQll9qC7FW+Gs61ECtC/QB6A",
+	"ghoTpOyhdZxL4lKXkBECEgplLOERFB8Es80JFzPzAF3wNDMHnaCcLEFyIRVJAnRJcDTSKuzBQ+faxc+E",
+	"ICxcjGzJvBFm0SgX5+HCWzebxJNfKLttIsy9MdsUby9/qe9O5HjptP4bdsPenF5cnp4cXZ++QUXA2HAZ",
+	"1DHUWhxPcaMOIEMHwat9TcEES1ITN1SiNMaMGa0JtXsSPifuswP3WdDt8FQnc8lk5JxomdNWPAde6hXN",
+	"aUSsJdAsYwRFFantD00wjTNRMZpCLDWIND0nWaxoGhOjiUwpNsJCzb1EmBIONWtYw8fvIBjQ5ZIm31/C",
+	"yuhvU2kScACjDTWHaLcBMEyVRP/n6rdf66LvHPafQCOhiBthmXKpJvS+qAE44QIxIoHrlKF0om0/7duY",
+	"RX0kgo8oi8i9Zlj0Tz1Xs7mF05Tgsk3BTYgI4Kg7gLqkevISRRlk10/M1zM81+CswTBAv1nTG+jz1Gyk",
+	"yMMbhtANhFVuBmhUIrb8oRWkhuWKMsXmQ1Am7/bfBx16MCaJmXxeQNl2cTNYq2zWEZplCWYjQXAEBl7p",
+	"dV69CZdUDAAhQOWK1NYItYwOknFk6nBiqFzl3TeHEljSuwWNLBetPakzK/pzS5kkqVpUKlVW2Cm3r3fO",
+	"5m+IwjSWv89ftfG6bWE3dK2ZnYcmUMGVhsPOj/6f07VOXBpDWnEnMMqfe6RGycLT3HwJ0C+YGqOrsmeV",
+	"7/7fQeXznOly+0YSVZgMoBrplMEZI8M85rovY74Upb9dpNodtYFSknnvxj2y9geWMkusfMFsUbRy9AbI",
+	"1XJvjmMaDbUNkrGoCId7fDzgcr90OzESwDCVFUjOGbOowlLykILKuqPKLMgAzQHTyOIA/aoFWRxX3hpp",
+	"5HBl+iSRlTyVKu3LYmdrqxpPJGgquK98moYCvCqBui7tfSCwHnl5rUH3hGw9qn6zg0HRbwxJnhBkMoOo",
+	"g3lEJxMiitQG69SQqBjiZ8qiL52pwFpDc7BjszV80Iu7wqMxYoeyaWy7Nz6iSy2zcZvoZYvkVmJxNFFw",
+	"6QbXy2kW+52Ua2/n1aQoK12xOOG2kGKOL8f7YJEpQbUuv9IYteaLSVYx0ZNyYgrIH4Vvibl8ATwCRRA2",
+	"936ObI43l3lHqqq98j5n/A7FnEGZ7DtMVT5LfOvSa+rdB93KJmbUQ/xvz97UsRm0oinHdxuq6vTr39fL",
+	"JBGjaUYjspf7VEJ+k1EfVW6pBpfoP7M0E6qxChsursBxnCsP9q1yLUxEy0Wf+pS2h05pC3nkc1Oy6dRI",
+	"zp+ury8cbnRby2LUBWiHaB/RvCZ0Rx6xinaHOrBkh/V5dTvOq9vCoyhXh4WANmk9cVvN4NuaLPJNi60c",
+	"kLvZojZzuJbHeGc3g38aO/BmYBe6hWeCjpylHsZYmPgXZob9LBSB/caZFpjEhDn5nAihrUyqvBBdUcLX",
+	"IqnACvoN9lIO0c3gKoOdTu2LivJKH5wctTUBwSk7+S6J2FpZeVMrv0FHmZqZqL9+dMOO4rjMfshtHR5d",
+	"nLlC6eiD/ogLG7o4RMcECyLQTba//zqEwD/8ST6gGXi9xhrDCPwTuzNAGUpjTNlIkXsFAYRrqMas31mN",
+	"zsc21D5e2M2LD8TMJlSxbarFjfpgLQH44co667cQQxFUe2Y03/6RoSCEBTeQEkMVFBG6ICLkDOerNaxU",
+	"2ik8HBwE+8G+TbdnOKWDw8HrYD94ZetZABXtmW3pkd08hmdTotp3uc2NxCaMWt3S1ojNCe8sst9UtvIl",
+	"pLoYXxaGerW/73bwiNk/gctEDGr3/mN53K5thRCpjgSpB0BHdT0IXDDJ4oJLNIy+3+FMTCayZ/C3TLYM",
+	"/8NjDH/mLBkbgCC24XAgsyTBYtEZzwpPZaNWCuQkpdx3QMJkadk7navdOftMM9R337mY3HffQVTuw4cP",
+	"+r9P+p8iRqelmXztaPZmMHSvtRRxr0uPi/wJ89L8Pii1yJNATAPz8/db/Ttvk+c82BHgZ62NSZkwDUg2",
+	"CglTAsejg5uBbvE5X9LyteGPmSBLlwctlqwwT/5Yskjb/+84hKDy72b81uXWWhfrLlbVEAAG7RXGHORX",
+	"bx1zU0Z/JzTvGcnmDXn44LpU86hChHZLwRU9Lidk2CyPx5FeveBaX3CtFjFL5NbnYUMT7n3SDPHZyLKY",
+	"eMshwXOjol3EpJnnVWUJ802dJUr5aYfvvBcxWpHczCKDcoxYzVxi6KG75L9Ku8MSDurm1/sGXX/vcyB7",
+	"+ltGf92IoV1xeq2uH4laj7x+JOqp01YvM58MzXYgryWWHlahtxqfUBTHLgHZhQ1aRgiQyfi1lTmqTc1+",
+	"VNAgck+S8NOg893bNe350N3sGgCKDNBvbdDNdwVdqKq3ep4TB6/HbSssIHs+c+QiL0tVkjvMCfvBsPlb",
+	"vtvfXNONUfP0p09l+Y/VPiDd+Qfs6W9jDbIFNTiKvP2btHRYHEgcufMs6wWmPCca/dEpz3mYhyS7tuM3",
+	"PeHtJE7VgnZHYIkH2e0hqyNfd8W2EWhIiT5ogv9QpNMGN+wYSxK5fC/33mwTpwTubUS3ZGEizNVcekZI",
+	"JCt9XWXhDGE5RHRiujpEaZJ8sBnOH/Tf0Fn5S5unErkYdmWMoDVK4zna9TAmzYoznC12zXk7Mr5c0MZ3",
+	"HK5n5a0iN+1Mt5KT21THppGcc++5eF84x8s7nf2RlvP3X3lg53sz14cd3idVGFdowjMWPf3wkp9CV+m7",
+	"jpGmpAP5/0jUdrR//oi038v9nrG6xMCSjbiqJRxmAjgbaBbz4ZPWLI9hG1YKLrTYhskq2/CLxLZ6IfHf",
+	"IyTW4OLVNiqrFJNo1cY4jss1JRLM8NSkFtmcH29Eo1Ip5sFou1rhozNZNwTv6jXWIGZsefj7856rlzly",
+	"gUt7dxBUu1meh9JyNW2Lb+y/H3UNQZxPul38utdfXAa3XAbrF70tcPzyrnnnVbQJ4Ff7B48/GXerthXL",
+	"Zh6vHn8eR/YCpz5M4QlTtMsOJ/sjL5zfbyLLNg1erJBr5punKdeGy0ZsAT4k3WtZA7aDPU14btPP37nk",
+	"uvf5VWu+hbtMxGfggK55kKcPSu4m3rI2w7cEWy7h9I1cj2V/JKrn12fKr1tbIz1bGrbsyDm7VMTuGr5N",
+	"vAr7bTe34jJv/DX4FfmteR0dC3cR6lPzLJas4wu4Fktm87i+xZKJ9M7FOs5FIUJahJqD9GZSbVv/ok3C",
+	"eR2MpyLh1rNY3I29W5kslxXx1fsYPdN3ZqyVfL+Rl9HGuE03o+fa5+tpbGCd9NzZxdVYiz3TzMueaYzD",
+	"dfWq2YnqOfQROPR5uEB2b7t3gdZ3gSZZ3Au8ssDrJpB26Yesl9df5wh/Un+NHuTTCKg8Div2xwl2d5zA",
+	"R20ttN+l9EW9u25Bwa8kGthZBz618N8TUXrdtF28eOCoXx/u2zLct1TErKNXN43rrZRS3sDe8/I8tvM4",
+	"+hBez8jLQ3hrMXXn8xgrObMZuevZ8jnE6Hq+28WpjTWZbo2Q3ErG88bket574tG3zVyOJxBu6+XFrmJb",
+	"D21975UOJGwc5EKukw6xruO8aS97nkkWYB+xe7iIXYl1dpgRmHN3KAhcw4BjubJcUrvQQeVuVtv0J5XW",
+	"PZs/eTYvENaz+UMY+jX+2a0CT6kSK3n7glOmRpSNrmlCkCBxLozs3RpbuvEXehI9rz8DXgdM9Vy+MZdv",
+	"y0m7Zf5y5v/m5nveSwf7/bJo23P7c0mu6y34B7TgS9yzk7wTwqaUdWDp4t78fEru02V8fJq3+e9POTFr",
+	"7al/e+pfSmx1sjdgX4/cS7vB63qppodlVuqpa/EcVFa+nOeiayx0ew7bpeuYU0Erc7XsEHkLAa3iler+",
+	"0FfOLg+3r9POKU97W6fn8J2W5VqDybUGLe5SXVnxHqc4pGoB9c0LlZ13sFXF+8vSla6PV/a+GLWnvs1r",
+	"329OF83a9/PiLuRWYnR3Ph7j8JawyN2HDFd4NojNXqD80DcquDucN68Ft3RV0K3BhdGWmYgHh4O9+cFA",
+	"qxULxzqwdJcLNaNsmseS7JWaBSeg0jEBq9g0Npr6sb0zJ8g9XdUDURt1WziVtV6d5thirqgUcvLPOT9P",
+	"s80oxca0fxBXEWWNMY7rV5vYnqs3m3x+//l/AwAA//9WYswOY/wAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/docs/spec/openapi.yml
+++ b/docs/spec/openapi.yml
@@ -1289,7 +1289,7 @@ components:
         region:
           type: string
           x-go-type-skip-optional-pointer: true
-        targetNamespaces:
+        allowedNamespaces:
           type: array
           description: List of namespaces allowed to use this backup storage
           items:
@@ -1300,7 +1300,7 @@ components:
         - accessKey
         - secretKey
         - type
-        - targetNamespaces
+        - allowedNamespaces
       additionalProperties: false
     UpdateBackupStorageParams:
       type: object
@@ -1319,7 +1319,7 @@ components:
           type: string
         region:
           type: string
-        targetNamespaces:
+        allowedNamespaces:
           type: array
           description: List of namespaces allowed to use this backup storage
           items:
@@ -1345,7 +1345,7 @@ components:
         region:
           type: string
           x-go-type-skip-optional-pointer: true
-        targetNamespaces:
+        allowedNamespaces:
           type: array
           description: List of namespaces allowed to use this backup storage
           items:
@@ -1355,7 +1355,7 @@ components:
         - name
         - bucketName
         - type
-        - targetNamespaces
+        - allowedNamespaces
     BackupStoragesList:
       type: array
       items:
@@ -1374,7 +1374,7 @@ components:
           type: string
           minLength: 1
           x-go-type-skip-optional-pointer: true
-        targetNamespaces:
+        allowedNamespaces:
           type: array
           description: List of namespaces allowed to use this monitoring instance
           items:
@@ -1416,7 +1416,7 @@ components:
       required:
         - type
         - url
-        - targetNamespaces
+        - allowedNamespaces
         - name
     MonitoringInstanceUpdateParams:
       description: Monitoring instance update information
@@ -1430,7 +1430,7 @@ components:
       required:
         - type
         - url
-        - targetNamespaces
+        - allowedNamespaces
         - name
     MonitoringInstancesList:
       type: array

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/labstack/echo/v4 v4.11.4
 	github.com/oapi-codegen/echo-middleware v1.0.1
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6
+	github.com/percona/everest-operator v0.6.0-dev1.0.20240220114053-fae6111d9818
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8P
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6 h1:leGa/XuWVstdYyj61r92xByjuT52jsbVroHB0fj4j7A=
-github.com/percona/everest-operator v0.6.0-dev1.0.20240207193854-cdd70b8eb1e6/go.mod h1:45pGpvWrPy495qiQqxNuOJor4wif+vTTTJP4Qee8qZk=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240220114053-fae6111d9818 h1:w4E4zlSTRQQk2/tFAFO5WGquvKRg2ocw7hxcbRjUT58=
+github.com/percona/everest-operator v0.6.0-dev1.0.20240220114053-fae6111d9818/go.mod h1:45pGpvWrPy495qiQqxNuOJor4wif+vTTTJP4Qee8qZk=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/percona/percona-postgresql-operator v0.0.0-20231220140959-ad5eef722609 h1:+UOK4gcHrRgqjo4smgfwT7/0apF6PhAJdQIdAV4ub/M=


### PR DESCRIPTION
[![EVEREST-107](https://badgen.net/badge/JIRA/EVEREST-107/green)](https://jira.percona.com/browse/EVEREST-107) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

TargetNamespaces wasn't very clear so we renamed it to AllowedNamespaces.

After fixing the perconalab/everest-catalog:latest image I'm re-opening the #456 without any changes.

[EVEREST-107]: https://perconadev.atlassian.net/browse/EVEREST-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ